### PR TITLE
FHG-5472 : Update Azure Identity to 1.11.4 up from 1.11.2

### DIFF
--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>2.3.2</VersionPrefix>
+    <VersionPrefix>2.3.3</VersionPrefix>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
@@ -25,7 +25,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.2" />
-	  <PackageReference Include="Azure.Identity" Version="1.11.2" />
+	  <PackageReference Include="Azure.Identity" Version="1.11.4" />
 	  <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
 	  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
 	  <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.10" />


### PR DESCRIPTION
Our build & test pipeline identifies the Azure.Identity NuGet package to have a severe vulnerability and so won't pass the tests. This PR updates the package version that patches out the vulnerability.