### PR TITLE
FHG-5471 : Update to the Pipeline

### DIFF
--- a/.github/workflows/build-upload-artifact.yml
+++ b/.github/workflows/build-upload-artifact.yml
@@ -61,3 +61,4 @@ jobs:
           name: ${{ steps.get-name.outputs.artifact_name }}
           path: ${{ env.BUILD_DIRECTORY }}
           if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -89,9 +89,3 @@ jobs:
           azure_resource_group: ${{ vars.AZURE_RESOURCE_GROUP }}
           azure_sql_server_resource_name: ${{ vars.AZURE_SQL_SERVER_RESOURCE_NAME }}
           az_firewall_rule_name: ${{ inputs.artifact_name }}
-
-      - name: Clear Artifact
-        if: always()
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: ${{ inputs.artifact_name }}

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -33,6 +33,11 @@ jobs:
     name: Download Artifact & Deploy Project
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
+    env:
+      KEYVAULT: ${{ vars.AZURE_RESOURCE_PREFIX }}-kv-fh-general
+      APP_NAME: ${{ vars.AZURE_RESOURCE_PREFIX }}-${{ inputs.azure_app_name }}
+      RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_PREFIX }}-familyhubs
+      SQL_SERVER: ${{ vars.AZURE_RESOURCE_PREFIX }}-as-fh-sql-server
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -68,14 +73,14 @@ jobs:
         id: substitution
         uses: ./.github/actions/variable-substitution
         with:
-          keyvault_name: ${{ vars.KEYVAULT_NAME }}
+          keyvault_name: ${{ env.KEYVAULT }}
           keyvault_prefix: ${{ inputs.keyvault_prefix }}
           files: "${{ github.workspace }}/src/${{ inputs.project_type }}/${{ inputs.artifact_name }}/src/${{ inputs.project_name }}/appsettings.json, ./out/appsettings.json"
 
       - name: Deploy Artifact to Azure
         uses: azure/webapps-deploy@v3
         with:
-          app-name: ${{ inputs.azure_app_name }}
+          app-name: ${{ env.APP_NAME }}
           publish-profile: ${{ steps.substitution.outputs.publish_profile }}
           package: ./out
 
@@ -86,6 +91,6 @@ jobs:
           db_context: ${{ inputs.database_context }}
           data_project_path: ${{ github.workspace }}/src/${{ inputs.project_type }}/${{ inputs.artifact_name }}/src/${{ inputs.data_project_name }}
           startup_project_path: ${{ github.workspace }}/src/${{ inputs.project_type }}/${{ inputs.artifact_name }}/src/${{ inputs.project_name }}
-          azure_resource_group: ${{ vars.AZURE_RESOURCE_GROUP }}
-          azure_sql_server_resource_name: ${{ vars.AZURE_SQL_SERVER_RESOURCE_NAME }}
+          azure_resource_group: ${{ env.RESOURCE_GROUP }}
+          azure_sql_server_resource_name: ${{ env.SQL_SERVER }}
           az_firewall_rule_name: ${{ inputs.artifact_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,19 +64,9 @@ jobs:
       project: ${{ matrix.project }}
     secrets: inherit
 
-  # This stage is useful for when redeployments are necessary, as it will trigger all the deploy jobs below to re-run ..
-  # .. when this step is ran again from the GitHub deployments area.
-  sync-deploy:
-    name: Synchronise Build and Deploy Stages
-    needs: [ build-projects-upload-artifacts ]
-    runs-on: 'ubuntu-latest'
-    steps:
-      - id: sync
-        run: echo "Build Finished, Deploying ..."
-
   api-idam-deploy:
     name: Deploy - IDAM API
-    needs: [ sync-deploy ]
+    needs: [ build-projects-upload-artifacts ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
                    src/ui/find-ui/,
                    src/ui/idam-maintenance-ui/,
                    src/ui/manage-ui/
-                   ]
+        ]
         include:
           - project: src/service/idam-api/
             job_name: "Build - IDAM API"
@@ -141,7 +141,12 @@ jobs:
 
   ui-connect-dashboard-deploy:
     name: Deploy - Connect Dashboard UI
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ build-projects-upload-artifacts,
+             api-idam-deploy,
+             api-notification-deploy,
+             api-referral-deploy,
+             api-report-deploy,
+             api-service-directory-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -154,7 +159,12 @@ jobs:
 
   ui-connect-deploy:
     name: Deploy - Connect UI
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ build-projects-upload-artifacts,
+             api-idam-deploy,
+             api-notification-deploy,
+             api-referral-deploy,
+             api-report-deploy,
+             api-service-directory-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -167,7 +177,12 @@ jobs:
 
   ui-find-deploy:
     name: Deploy - Find UI
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ build-projects-upload-artifacts,
+             api-idam-deploy,
+             api-notification-deploy,
+             api-referral-deploy,
+             api-report-deploy,
+             api-service-directory-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -180,7 +195,12 @@ jobs:
 
   ui-idam-maintenance-deploy:
     name: Deploy - IDAM Maintenance UI
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ build-projects-upload-artifacts,
+             api-idam-deploy,
+             api-notification-deploy,
+             api-referral-deploy,
+             api-report-deploy,
+             api-service-directory-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -193,7 +213,12 @@ jobs:
 
   ui-manage-deploy:
     name: Deploy - Manage UI
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ build-projects-upload-artifacts,
+             api-idam-deploy,
+             api-notification-deploy,
+             api-referral-deploy,
+             api-report-deploy,
+             api-service-directory-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,6 @@ jobs:
     uses: ./.github/workflows/build-upload-artifact.yml
     with:
       project: ${{ matrix.project }}
-    secrets: inherit
 
   api-idam-deploy:
     name: Deploy - IDAM API

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,9 @@ jobs:
     name: Synchronise Build and Deploy Stages
     needs: [ build-projects-upload-artifacts ]
     runs-on: 'ubuntu-latest'
+    steps:
+      - id: sync
+        run: echo "Build Finished, Deploying ..."
 
   api-idam-deploy:
     name: Deploy - IDAM API

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
                    src/ui/find-ui/,
                    src/ui/idam-maintenance-ui/,
                    src/ui/manage-ui/
-        ]
+                 ]
         include:
           - project: src/service/idam-api/
             job_name: "Build - IDAM API"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
 
   api-notification-deploy:
     name: Deploy - Notification API
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ api-idam-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -96,7 +96,7 @@ jobs:
 
   api-referral-deploy:
     name: Deploy - Referral API
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ api-notification-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -111,7 +111,7 @@ jobs:
 
   api-report-deploy:
     name: Deploy - Report API
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ api-referral-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -126,7 +126,7 @@ jobs:
 
   api-service-directory-deploy:
     name: Deploy - Service Directory API
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ api-report-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -141,12 +141,7 @@ jobs:
 
   ui-connect-dashboard-deploy:
     name: Deploy - Connect Dashboard UI
-    needs: [ build-projects-upload-artifacts,
-             api-idam-deploy,
-             api-notification-deploy,
-             api-referral-deploy,
-             api-report-deploy,
-             api-service-directory-deploy ]
+    needs: [ api-service-directory-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -159,12 +154,7 @@ jobs:
 
   ui-connect-deploy:
     name: Deploy - Connect UI
-    needs: [ build-projects-upload-artifacts,
-             api-idam-deploy,
-             api-notification-deploy,
-             api-referral-deploy,
-             api-report-deploy,
-             api-service-directory-deploy ]
+    needs: [ ui-connect-dashboard-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -177,12 +167,7 @@ jobs:
 
   ui-find-deploy:
     name: Deploy - Find UI
-    needs: [ build-projects-upload-artifacts,
-             api-idam-deploy,
-             api-notification-deploy,
-             api-referral-deploy,
-             api-report-deploy,
-             api-service-directory-deploy ]
+    needs: [ ui-connect-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -195,12 +180,7 @@ jobs:
 
   ui-idam-maintenance-deploy:
     name: Deploy - IDAM Maintenance UI
-    needs: [ build-projects-upload-artifacts,
-             api-idam-deploy,
-             api-notification-deploy,
-             api-referral-deploy,
-             api-report-deploy,
-             api-service-directory-deploy ]
+    needs: [ ui-find-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
@@ -213,12 +193,7 @@ jobs:
 
   ui-manage-deploy:
     name: Deploy - Manage UI
-    needs: [ build-projects-upload-artifacts,
-             api-idam-deploy,
-             api-notification-deploy,
-             api-referral-deploy,
-             api-report-deploy,
-             api-service-directory-deploy ]
+    needs: [ ui-idam-maintenance-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,9 +64,16 @@ jobs:
       project: ${{ matrix.project }}
     secrets: inherit
 
+  # This stage is useful for when redeployments are necessary, as it will trigger all the deploy jobs below to re-run ..
+  # .. when this step is ran again from the GitHub deployments area.
+  sync-deploy:
+    name: Synchronise Build and Deploy Stages
+    needs: [ build-projects-upload-artifacts ]
+    runs-on: 'ubuntu-latest'
+
   api-idam-deploy:
     name: Deploy - IDAM API
-    needs: [ build-projects-upload-artifacts ]
+    needs: [ sync-deploy ]
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
       data_project_name: FamilyHubs.Idam.Data
       database_context: ApplicationDbContext
       project_type: service
-      azure_app_name: s181d01-as-fh-idam-api
+      azure_app_name: as-fh-idam-api
     secrets: inherit
 
   api-notification-deploy:
@@ -91,7 +91,7 @@ jobs:
       data_project_name: FamilyHubs.Notification.Data
       database_context: ApplicationDbContext
       project_type: service
-      azure_app_name: s181d01-as-fh-notification-api
+      azure_app_name: as-fh-notification-api
     secrets: inherit
 
   api-referral-deploy:
@@ -106,7 +106,7 @@ jobs:
       data_project_name: FamilyHubs.Referral.Data
       database_context: ApplicationDbContext
       project_type: service
-      azure_app_name: s181d01-as-fh-referral-api
+      azure_app_name: as-fh-referral-api
     secrets: inherit
 
   api-report-deploy:
@@ -121,7 +121,7 @@ jobs:
       data_project_name: FamilyHubs.Report.Data
       database_context: ReportDbContext
       project_type: service
-      azure_app_name: s181d01-as-fh-report-api
+      azure_app_name: as-fh-report-api
     secrets: inherit
 
   api-service-directory-deploy:
@@ -136,7 +136,7 @@ jobs:
       data_project_name: FamilyHubs.ServiceDirectory.Data
       database_context: ApplicationDbContext
       project_type: service
-      azure_app_name: s181d01-as-fh-sd-api
+      azure_app_name: as-fh-sd-api
     secrets: inherit
 
   ui-connect-dashboard-deploy:
@@ -154,7 +154,7 @@ jobs:
       keyvault_prefix: CONNECT-DASHBOARD-UI
       project_name: FamilyHubs.RequestForSupport.Web
       project_type: ui
-      azure_app_name: s181d01-as-fh-ref-dash-ui
+      azure_app_name: as-fh-ref-dash-ui
     secrets: inherit
 
   ui-connect-deploy:
@@ -172,7 +172,7 @@ jobs:
       keyvault_prefix: CONNECT-UI
       project_name: FamilyHubs.Referral.Web
       project_type: ui
-      azure_app_name: s181d01-as-fh-referral-ui
+      azure_app_name: as-fh-referral-ui
     secrets: inherit
 
   ui-find-deploy:
@@ -190,7 +190,7 @@ jobs:
       keyvault_prefix: FIND-UI
       project_name: FamilyHubs.ServiceDirectory.Web
       project_type: ui
-      azure_app_name: s181d01-as-fh-sd-ui
+      azure_app_name: as-fh-sd-ui
     secrets: inherit
 
   ui-idam-maintenance-deploy:
@@ -208,7 +208,7 @@ jobs:
       keyvault_prefix: IDAM-MAINTENANCE-UI
       project_name: FamilyHubs.Idams.Maintenance.UI
       project_type: ui
-      azure_app_name: s181d01-as-fh-idam-maintenance-ui
+      azure_app_name: as-fh-idam-maintenance-ui
     secrets: inherit
 
   ui-manage-deploy:
@@ -226,5 +226,5 @@ jobs:
       keyvault_prefix: MANAGE-UI
       project_name: FamilyHubs.ServiceDirectory.Admin.Web
       project_type: ui
-      azure_app_name: s181d01-as-fh-sd-admin-ui
+      azure_app_name: as-fh-sd-admin-ui
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ permissions:
   id-token: write
   contents: read
 
+# TODO: Review sequential running of "deploy" stages
+#   We currently run each "deploy" stage in sequential order as our App Service Plans are too weak, when we action ..
+#   .. this and upgrade we should look into parallelising the "deploy" stages again.
 jobs:
   build-projects-upload-artifacts:
     name: ${{ matrix.job_name }}


### PR DESCRIPTION
Rejigging a few small things about the pipeline.

---

Pipeline run: https://github.com/DFE-Digital/fh-services/actions/runs/10057883102

---

Effects of the changes:

- We can redeploy an older release up to the retention period of the artifacts, because they are no longer instantly deleted at the end of the pipeline.

- Fewer secrets and vars per environment. We now have per environment 3 secrets (for Azure connection) and 1 var (described below), everything else required for the services to function is in KeyVault

- `app-name` needed to be generic in `deploy.yml`, so I added a new environment variable that is just the resource prefix of Azure (e.g., `s181d01`), and then decided to compute the rest of the names of things (SQL server, resource group, keyvault) instead of storing them as individual variables in GitHub.

- The Dev (and Test for now) are on S1 plans, and it turns out deploying 10 services at once is overwhelming it and so we occasionally see a failed deployment or two, so for now I just have it deploy one at a time sequentially, this can be changed back to being parallel as each environment matches Prod and becomes S3. Since the build stage is running in Git, those are still fully parallel :)