### PR TITLE
Pipeline Tweaks for Deployment

### DIFF
--- a/.github/actions/variable-substitution/action.yml
+++ b/.github/actions/variable-substitution/action.yml
@@ -97,3 +97,6 @@ runs:
         Notification.Endpoint: ${{ steps.fetch.outputs.NOTIFICATION_ENDPOINT }}
         ReferralApiBaseUrl: ${{ steps.fetch.outputs.REFERRALAPIBASEURL }}
         ReportingApiBaseUrl: ${{ steps.fetch.outputs.REPORTINGAPIBASEURL }}
+        FamilyHubsUi.Analytics.ContainerId: ${{ steps.fetch.outputs.FAMILYHUBSUI_ANALYTICS_CONTAINERID }}
+        FamilyHubsUi.Analytics.MeasurementId: ${{ steps.fetch.outputs.FAMILYHUBSUI_ANALYTICS_MEASUREMENTID }}
+        FamilyHubsUi.Analytics.ClarityId: ${{ steps.fetch.outputs.FAMILYHUBSUI_ANALYTICS_CLARITYID }}

--- a/.github/actions/variable-substitution/action.yml
+++ b/.github/actions/variable-substitution/action.yml
@@ -60,7 +60,6 @@ runs:
         Crypto.KeyVaultIdentifier: ${{ steps.fetch.outputs.CRYPTO_KEYVAULTIDENTIFIER }}
         Crypto.tenantId: ${{ steps.fetch.outputs.CRYPTO_TENANTID }}
         Crypto.UseKeyVault: ${{ steps.fetch.outputs.CRYPTO_USEKEYVAULT }}
-        EventGridUrl: ${{ steps.fetch.outputs.EVENTGRIDURL }}
         GovUkOidcConfiguration.BearerTokenSigningKey: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_BEARERTOKENSIGNINGKEY }}
         ServiceDirectoryApiBaseUrl: ${{ steps.fetch.outputs.SERVICEDIRECTORYAPIBASEURL }}
         ConnectionStrings.ServiceDirectoryConnection: ${{ steps.fetch.outputs.CONNECTIONSTRINGS_SERVICEDIRECTORYCONNECTION }}
@@ -74,8 +73,6 @@ runs:
         ServiceDirectoryUrl: ${{ steps.fetch.outputs.SERVICEDIRECTORYURL }}
         ReferralApiUrl: ${{ steps.fetch.outputs.REFERRALAPIURL }}
         Idams.Endpoint: ${{ steps.fetch.outputs.IDAMS_ENDPOINT }}
-        GovUkOidcConfiguration.PathBasedRouting.SubSiteTriggerPaths: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_PATHBASEDROUTING_SUBSITETRIGGERPATHS }}
-        GovUkOidcConfiguration.PathBasedRouting.DiscriminatorPath: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_PATHBASEDROUTING_DISCRIMINATORPATH }}
         FamilyHubsUi.Urls.GovUkLoginAccountPage: ${{ steps.fetch.outputs.FAMILYHUBSUI_URLS_GOVUKLOGINACCOUNTPAGE }}
         FamilyHubsUi.Urls.DashboardWeb: ${{ steps.fetch.outputs.FAMILYHUBSUI_URLS_DASHBOARDWEB }}
         DataProtection.TenantId: ${{ steps.fetch.outputs.DATAPROTECTION_TENANTID }}
@@ -84,8 +81,6 @@ runs:
         DataProtection.ClientId: ${{ steps.fetch.outputs.DATAPROTECTION_CLIENTID }}
         ConnectionStrings.SharedKernelConnection: ${{ steps.fetch.outputs.CONNECTIONSTRINGS_SHAREDKERNELCONNECTION }}
         ServiceDirectoryAPI.Endpoint: ${{ steps.fetch.outputs.SERVICEDIRECTORYAPI_ENDPOINT }}
-        BlobStorageFilename: ${{ steps.fetch.outputs.BLOBSTORAGEFILENAME }}
-        BlobStorageConnectionString: ${{ steps.fetch.outputs.BLOBSTORAGECONNECTIONSTRING }}
         SqlServerCache.Connection: ${{ steps.fetch.outputs.SQLSERVERCACHE_CONNECTION }}
         CacheConnection: ${{ steps.fetch.outputs.CACHECONNECTION }}
         FamilyHubsUi.Urls.ConnectWeb: ${{ steps.fetch.outputs.FAMILYHUBSUI_URLS_CONNECTWEB }}
@@ -98,11 +93,6 @@ runs:
         GovUkOidcConfiguration.Oidc.ClientId: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_OIDC_CLIENTID }}
         GovUkOidcConfiguration.Oidc.KeyVaultIdentifier: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_OIDC_KEYVAULTIDENTIFIER }}
         GovUkOidcConfiguration.Oidc.TwoFactorEnabled: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_OIDC_TWOFACTORENABLED }}
-        GovUkOidcConfiguration.StubAuthentication.UseStubAuthentication: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_STUBAUTHENTICATION_USESTUBAUTHENTICATION }}
-        GovUkOidcConfiguration.StubAuthentication.UseStubClaims: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_STUBAUTHENTICATION_USESTUBCLAIMS }}
-        GovUkOidcConfiguration.Urls.NoClaimsRedirect: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_URLS_NOCLAIMSREDIRECT }}
-        GovUkOidcConfiguration.Urls.SignedOutRedirect: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_URLS_SIGNEDOUTREDIRECT }}
-        GovUkOidcConfiguration.Urls.TermsAndConditionsRedirect: ${{ steps.fetch.outputs.GOVUKOIDCCONFIGURATION_URLS_TERMSANDCONDITIONSREDIRECT }}
         IdamApi: ${{ steps.fetch.outputs.IDAMAPI }}
         Notification.Endpoint: ${{ steps.fetch.outputs.NOTIFICATION_ENDPOINT }}
         ReferralApiBaseUrl: ${{ steps.fetch.outputs.REFERRALAPIBASEURL }}

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -50,6 +50,7 @@ jobs:
           dotnet-version: ${{ vars.DOTNET_VERSION }}
 
       - name: Install Entity Framework
+        if: ${{ inputs.data_project_name != '' && inputs.database_context != ''}}
         shell: bash
         run: dotnet tool install --global dotnet-ef
 

--- a/src/ui/connect-dashboard-ui/src/FamilyHubs.RequestForSupport.Web/appsettings.json
+++ b/src/ui/connect-dashboard-ui/src/FamilyHubs.RequestForSupport.Web/appsettings.json
@@ -34,13 +34,13 @@
       "TwoFactorEnabled": true
     },
     "Urls": {
-      "SignedOutRedirect": "/",
+      "SignedOutRedirect": "/signout",
       "NoClaimsRedirect": "/Error/401",
       "TermsAndConditionsRedirect": "/terms-of-use"
     },
     "PathBasedRouting": {
-      "DiscriminatorPath": "",
-      "SubSiteTriggerPaths": ""
+      "DiscriminatorPath": "/referrals",
+      "SubSiteTriggerPaths": "/la,/vcs,/start"
     },
     "CookieName": "connect-auth",
     "ExpiryInMinutes": 15,

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/appsettings.json
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/appsettings.json
@@ -48,13 +48,13 @@
       "TwoFactorEnabled": true
     },
     "Urls": {
-      "SignedOutRedirect": "/",
+      "SignedOutRedirect": "/signout",
       "NoClaimsRedirect": "/Error/401",
       "TermsAndConditionsRedirect": "/terms-of-use"
     },
     "PathBasedRouting": {
-      "DiscriminatorPath": "",
-      "SubSiteTriggerPaths": ""
+      "DiscriminatorPath": "/referrals",
+      "SubSiteTriggerPaths": "/la,/vcs,/start"
     },
     "CookieName": "connect-auth",
     "IdamsApiBaseUrl": "https://localhost:7030",

--- a/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.UI/appsettings.json
+++ b/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.UI/appsettings.json
@@ -42,8 +42,8 @@
       "TwoFactorEnabled": false
     },
     "Urls": {
-      "SignedOutRedirect": "https://localhost:7216/signout",
-      "NoClaimsRedirect": "https://localhost:7216/Error/401"
+      "SignedOutRedirect": "/signout",
+      "NoClaimsRedirect": "/Error/401"
     },
     "IdamsApiBaseUrl": "https://localhost:7030",
     "StubAuthentication": {

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/appsettings.json
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/appsettings.json
@@ -22,9 +22,9 @@
       "TwoFactorEnabled": true
     },
     "Urls": {
-      "SignedOutRedirect": "https://localhost:7216/signout",
-      "NoClaimsRedirect": "https://localhost:7216/Error/401",
-      "TermsAndConditionsRedirect": "https://localhost:7216/AgreeToTermsAndConditions"
+      "SignedOutRedirect": "/signout",
+      "NoClaimsRedirect": "/Error/401",
+      "TermsAndConditionsRedirect": "/AgreeToTermsAndConditions"
     },
     "IdamsApiBaseUrl": "https://localhost:7030",
     "StubAuthentication": {


### PR DESCRIPTION
This PR solves an issue where some keys are overwritten because they aren't in the KV but are in the appsettings, but when investigated by myself and @stevesatdfe we discovered that those values are not secret and are the same across all services, or simply aren't used anywhere in the code (EventGridUrl and Blob Storage stuff for example) so have been added into the appsettings and/or removed from the variable transform instead.

It also adds the keys in for analytics as they were missed in the original KV secret populating

Also skips installing entity framework if DB migrations don't have to be applied (the UIs) as an easy low hanging fruit tweak