### PR TITLE
FHB-45 : Revert ClarityId in Connection Requests Made

### DIFF
--- a/.github/actions/variable-substitution/action.yml
+++ b/.github/actions/variable-substitution/action.yml
@@ -99,4 +99,4 @@ runs:
         ReportingApiBaseUrl: ${{ steps.fetch.outputs.REPORTINGAPIBASEURL }}
         FamilyHubsUi.Analytics.ContainerId: ${{ steps.fetch.outputs.FAMILYHUBSUI_ANALYTICS_CONTAINERID }}
         FamilyHubsUi.Analytics.MeasurementId: ${{ steps.fetch.outputs.FAMILYHUBSUI_ANALYTICS_MEASUREMENTID }}
-        FamilyHubsUi.Analytics.ClarityId: ${{ steps.fetch.outputs.FAMILYHUBSUI_ANALYTICS_CLARITYID }}
+        FamilyHubsUi.Analytics.ClarityId: ""


### PR DESCRIPTION
Technically this is set up such that when the clarity tags are added to KeyVault they will just be picked up on the next deployment, but we wouldn't actually want this for the connection requests made release so I've set it to an empty string for this release, mirroring what we did on ADO but for GitHub deployments.