### PR TITLE
FHB-45 : Add ClarityId to Substitution

### DIFF
--- a/.github/actions/variable-substitution/action.yml
+++ b/.github/actions/variable-substitution/action.yml
@@ -99,4 +99,4 @@ runs:
         ReportingApiBaseUrl: ${{ steps.fetch.outputs.REPORTINGAPIBASEURL }}
         FamilyHubsUi.Analytics.ContainerId: ${{ steps.fetch.outputs.FAMILYHUBSUI_ANALYTICS_CONTAINERID }}
         FamilyHubsUi.Analytics.MeasurementId: ${{ steps.fetch.outputs.FAMILYHUBSUI_ANALYTICS_MEASUREMENTID }}
-        FamilyHubsUi.Analytics.ClarityId: ""
+        FamilyHubsUi.Analytics.ClarityId: ${{ steps.fetch.outputs.FAMILYHUBSUI_ANALYTICS_CLARITYID }}

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/appsettings.json
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/appsettings.json
@@ -105,7 +105,7 @@
       "CookieVersion": 1,
       "MeasurementId": "",
       "ContainerId": "",
-      "ClarityId": "lwxqmeq8no"
+      "ClarityId": ""
     },
     "Header": {
       "NavigationLinks": [

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/appsettings.json
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/appsettings.json
@@ -19,7 +19,7 @@
       "CookieVersion": 1,
       "MeasurementId": "",
       "ContainerId": "",
-      "ClarityId" : "lvdgkygesf"
+      "ClarityId" : ""
     },
     "Footer": {
       "Links": [

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/appsettings.json
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/appsettings.json
@@ -73,7 +73,7 @@
       "CookieVersion": 1,
       "MeasurementId": "",
       "ContainerId": "",
-      "ClarityId": "lwxri5if2d"
+      "ClarityId": ""
     },
     "Header": {
       "ActionLinks": [


### PR DESCRIPTION
This PR allows the app substitution to read the clarity IDs from KeyVault for each UI and add it to its appsettings