### PR TITLE
FHB-543 : Hotfix to Revert Appsettings

### DIFF
--- a/src/ui/connect-dashboard-ui/src/FamilyHubs.RequestForSupport.Web/appsettings.json
+++ b/src/ui/connect-dashboard-ui/src/FamilyHubs.RequestForSupport.Web/appsettings.json
@@ -34,7 +34,7 @@
       "TwoFactorEnabled": true
     },
     "Urls": {
-      "SignedOutRedirect": "/signout",
+      "SignedOutRedirect": "/",
       "NoClaimsRedirect": "/Error/401",
       "TermsAndConditionsRedirect": "/terms-of-use"
     },

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/appsettings.json
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/appsettings.json
@@ -48,7 +48,7 @@
       "TwoFactorEnabled": true
     },
     "Urls": {
-      "SignedOutRedirect": "/signout",
+      "SignedOutRedirect": "/",
       "NoClaimsRedirect": "/Error/401",
       "TermsAndConditionsRedirect": "/terms-of-use"
     },


### PR DESCRIPTION
This PR reverts changes to the signout URL in the appsettings for connect and the connect dashboard, as they failed to redirect with the new URLs.