### PR TITLE
FHB-537 : Show VCFS Services in Connect if they are within a Family Hub

### DIFF
--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Core/ApiClients/OrganisationClientService.cs
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Core/ApiClients/OrganisationClientService.cs
@@ -144,7 +144,7 @@ public class OrganisationClientService : ApiService, IOrganisationClientService
 
     private static string GetPositionUrl(string? serviceType, double? latitude, double? longitude, double? proximity, string status, int pageNumber, int pageSize)
     {
-        return $"api/services-simple?serviceType={serviceType}&status={status}&pageNumber={pageNumber}&pageSize={pageSize}&isFamilyHub=false{(
+        return $"api/services-simple?serviceType={serviceType}&status={status}&pageNumber={pageNumber}&pageSize={pageSize}{(
                 latitude != null ? $"&latitude={latitude}" : string.Empty)}{(
                 longitude != null ? $"&longitude={longitude}" : string.Empty)}{(
                 proximity != null ? $"&proximity={proximity}" : string.Empty)}";


### PR DESCRIPTION
Ticket: [FHB-537](https://dfedigital.atlassian.net/browse/FHB-537)

---

This PR enables VCFS services to be shown on the Connect results page if they are inside a Family Hub, alongside services that aren't.

[FHB-537]: https://dfedigital.atlassian.net/browse/FHB-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ