### PR TITLE
FHB-52 Service detail page changes part 2

### DIFF
--- a/src/ui/connect-ui/README.md
+++ b/src/ui/connect-ui/README.md
@@ -66,4 +66,3 @@ To debug the JavaScript in Visual Studio, set breakpoints in the JavaScript file
 * add prg to telephone, text & letter & switch to standard ErrorState
 
 * change ErrorId to static const class with const ints?
-


### PR DESCRIPTION
Adds the display of service-level schedules to the service details page, matching how services are displayed in Manage.
How we display service-level schedules is being revisited. If we display them the same as Manage, this should be good to do.
If we decide to change the display to better handle possible combinations in LA ingested services, then it'll need to be reworked appropiately.