### PR TITLE
FHB-87 : Move Component to Shared Kernel

### DIFF
--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>2.4.0</VersionPrefix>
+    <VersionPrefix>2.5.0</VersionPrefix>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/ServicesTemp.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/ServicesTemp.cs
@@ -1,0 +1,8 @@
+namespace FamilyHubs.SharedKernel.OpenReferral;
+
+public class ServicesTemp
+{
+    public Guid Id { get; set; }
+    public required string Json { get; set; }
+    public required DateTime LastModified { get; set; }
+}


### PR DESCRIPTION
Quick PR to add the `ServicesTemp` entity to the Shared Kernel, as both `service-directory-api` and `open-referral-function` use it.