### PR TITLE
Feature/FHB-365 remove nuget packages for references

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ["main", "release-*", "feature/fhb-365-remove-nuget-packages-for-references"]
+    branches: ["main", "release-*"]
   pull_request:
     paths:
       - '.github/workflows/build-and-test.yml'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ["main", "release-*"]
+    branches: ["main", "release-*", "feature/fhb-365-remove-nuget-packages-for-references"]
   pull_request:
     paths:
       - '.github/workflows/build-and-test.yml'

--- a/src/service/idam-api/src/FamilyHubs.Idam.Core/FamilyHubs.Idam.Core.csproj
+++ b/src/service/idam-api/src/FamilyHubs.Idam.Core/FamilyHubs.Idam.Core.csproj
@@ -10,8 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.1.1" />
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="FamilyHubs.ReferralService.Shared" Version="1.0.15" />
-    <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.1.0" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="9.23.0.88079">
@@ -21,6 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\referral-shared\src\FamilyHubs.ReferralService.Shared\FamilyHubs.ReferralService.Shared.csproj" />
+    <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
     <ProjectReference Include="..\FamilyHubs.Idam.Data\FamilyHubs.Idam.Data.csproj" />
   </ItemGroup>
 

--- a/src/service/idam-api/src/FamilyHubs.Idam.Data/FamilyHubs.Idam.Data.csproj
+++ b/src/service/idam-api/src/FamilyHubs.Idam.Data/FamilyHubs.Idam.Data.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FamilyHubs.SharedKernel" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.14">
       <PrivateAssets>all</PrivateAssets>
@@ -27,6 +26,10 @@
 
   <ItemGroup>
     <Folder Include="Migrations\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/service/notification-api/src/FamilyHubs.Notification.Api.Client/FamilyHubs.Notification.Api.Client.csproj
+++ b/src/service/notification-api/src/FamilyHubs.Notification.Api.Client/FamilyHubs.Notification.Api.Client.csproj
@@ -16,8 +16,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FamilyHubs.SharedKernel" Version="2.0.53" />
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.15" />
 		<PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
 		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.8.0.76515">
 			<PrivateAssets>all</PrivateAssets>
@@ -26,6 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
 	  <ProjectReference Include="..\..\shared\FamilyHubs.Notification.Api.Contracts\FamilyHubs.Notification.Api.Contracts.csproj" />
 	</ItemGroup>
 

--- a/src/service/notification-api/src/FamilyHubs.Notification.Data/FamilyHubs.Notification.Data.csproj
+++ b/src/service/notification-api/src/FamilyHubs.Notification.Data/FamilyHubs.Notification.Data.csproj
@@ -13,12 +13,11 @@
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
 		<PackageReference Include="EncryptColumn.Core" Version="1.0.0" />
 		<PackageReference Include="FamilyHubs.Notification.Api.Contracts" Version="1.0.3" />
-		<PackageReference Include="FamilyHubs.SharedKernel" Version="2.0.53" />
 		<PackageReference Include="GovukNotify" Version="6.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.10" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.10" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.10" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.14" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.10">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -29,6 +28,10 @@
 
 	<ItemGroup>
 	  <Folder Include="Repository\" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/service/referral-api/acceptance-tests/FamilyHubs.Referral.Api.AcceptanceTests/FamilyHubs.Referral.Api.AcceptanceTests.csproj
+++ b/src/service/referral-api/acceptance-tests/FamilyHubs.Referral.Api.AcceptanceTests/FamilyHubs.Referral.Api.AcceptanceTests.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FamilyHubs.ReferralService.Shared" Version="1.1.5" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
@@ -35,6 +34,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <DependentUpon>appsettings.json</DependentUpon>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\referral-shared\src\FamilyHubs.ReferralService.Shared\FamilyHubs.ReferralService.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/service/referral-api/src/FamilyHubs.Referral.Api/FamilyHubs.Referral.Api.csproj
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Api/FamilyHubs.Referral.Api.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FamilyHubs.SharedKernel" Version="2.3.2" />
     <PackageReference Include="FamilyHubs.SharedKernel.Razor" Version="9.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.14">
@@ -29,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
     <ProjectReference Include="..\FamilyHubs.Referral.Core\FamilyHubs.Referral.Core.csproj" />
   </ItemGroup>
 

--- a/src/service/referral-api/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
@@ -10,7 +10,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Messaging.EventGrid" Version="4.18.0" />
-		<PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.12.0" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
 		<PackageReference Include="LinqKit.Core" Version="1.2.4" />
 		<PackageReference Include="MediatR" Version="12.1.1" />
@@ -23,6 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
 	  <ProjectReference Include="..\FamilyHubs.Referral.Data\FamilyHubs.Referral.Data.csproj" />
 	</ItemGroup>
 

--- a/src/service/referral-api/src/FamilyHubs.Referral.Data/FamilyHubs.Referral.Data.csproj
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Data/FamilyHubs.Referral.Data.csproj
@@ -12,8 +12,6 @@
 		<PackageReference Include="Ardalis.GuardClauses" Version="4.1.1" />
 		<PackageReference Include="AutoMapper.Collection.EntityFrameworkCore" Version="9.0.0" />
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-		<PackageReference Include="FamilyHubs.ReferralService.Shared" Version="1.1.5" />
-		<PackageReference Include="FamilyHubs.SharedKernel" Version="2.3.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.11" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.14" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.14" />
@@ -32,6 +30,11 @@
 
   <ItemGroup>
     <Folder Include="Migrations\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\referral-shared\src\FamilyHubs.ReferralService.Shared\FamilyHubs.ReferralService.Shared.csproj" />
+    <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/service/report-api/acceptance-tests/FamilyHubs.Report.Api.AcceptanceTests/FamilyHubs.Report.Api.AcceptanceTests.csproj
+++ b/src/service/report-api/acceptance-tests/FamilyHubs.Report.Api.AcceptanceTests/FamilyHubs.Report.Api.AcceptanceTests.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FamilyHubs.SharedKernel" Version="2.4.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
@@ -37,6 +36,10 @@
 
   <ItemGroup>
     <Folder Include="Models\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/service/report-api/src/FamilyHubs.Report.Api/FamilyHubs.Report.Api.csproj
+++ b/src/service/report-api/src/FamilyHubs.Report.Api/FamilyHubs.Report.Api.csproj
@@ -11,7 +11,6 @@
     <ItemGroup>
         <PackageReference Include="FamilyHubs.SharedKernel.Razor" Version="9.3.1" />
         <PackageReference Include="EFCoreSecondLevelCacheInterceptor" Version="4.4.1" />
-        <PackageReference Include="FamilyHubs.SharedKernel" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.17" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.19" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.19">
@@ -28,6 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
         <ProjectReference Include="..\FamilyHubs.Report.Core\FamilyHubs.Report.Core.csproj" />
         <ProjectReference Include="..\FamilyHubs.Report.Data\FamilyHubs.Report.Data.csproj" />
     </ItemGroup>

--- a/src/service/report-api/src/FamilyHubs.Report.Core/FamilyHubs.Report.Core.csproj
+++ b/src/service/report-api/src/FamilyHubs.Report.Core/FamilyHubs.Report.Core.csproj
@@ -7,12 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
+        <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
         <ProjectReference Include="..\FamilyHubs.Report.Data\FamilyHubs.Report.Data.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.11.0" />
-        <PackageReference Include="FamilyHubs.SharedKernel" Version="2.4.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />
     </ItemGroup>
 

--- a/src/service/report-api/src/FamilyHubs.Report.Data/FamilyHubs.Report.Data.csproj
+++ b/src/service/report-api/src/FamilyHubs.Report.Data/FamilyHubs.Report.Data.csproj
@@ -7,14 +7,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.10.0" />
-		<PackageReference Include="FamilyHubs.SharedKernel" Version="2.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.19" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.19">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.19" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
+      <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/service/report-api/tests/FamilyHubs.ReportApi.FunctionalTests/FamilyHubs.ReportApi.FunctionalTests.csproj
+++ b/src/service/report-api/tests/FamilyHubs.ReportApi.FunctionalTests/FamilyHubs.ReportApi.FunctionalTests.csproj
@@ -10,7 +10,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FamilyHubs.SharedKernel" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.17" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.19" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
@@ -26,6 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
       <ProjectReference Include="..\..\src\FamilyHubs.Report.Api\FamilyHubs.Report.Api.csproj" />
       <ProjectReference Include="..\..\src\FamilyHubs.Report.Data\FamilyHubs.Report.Data.csproj" />
     </ItemGroup>

--- a/src/service/report-api/tests/FamilyHubs.ReportApi.UnitTests/FamilyHubs.ReportApi.UnitTests.csproj
+++ b/src/service/report-api/tests/FamilyHubs.ReportApi.UnitTests/FamilyHubs.ReportApi.UnitTests.csproj
@@ -12,7 +12,6 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="FamilyHubs.SharedKernel" Version="2.4.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
       <PackageReference Include="NSubstitute" Version="5.1.0" />
       <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
@@ -27,6 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
       <ProjectReference Include="..\..\src\FamilyHubs.Report.Core\FamilyHubs.Report.Core.csproj" />
       <ProjectReference Include="..\..\src\FamilyHubs.Report.Data\FamilyHubs.Report.Data.csproj" />
     </ItemGroup>

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/FamilyHubs.ServiceDirectory.Data.csproj
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/FamilyHubs.ServiceDirectory.Data.csproj
@@ -10,8 +10,6 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.12.0" />
-		<PackageReference Include="FamilyHubs.SharedKernel" Version="2.3.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.14" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="7.0.18" />
@@ -32,6 +30,11 @@
 
 	<ItemGroup>
 	  <Folder Include="Migrations\" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
+	  <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/shared/referral-shared/src/FamilyHubs.ReferralService.Shared/FamilyHubs.ReferralService.Shared.csproj
+++ b/src/shared/referral-shared/src/FamilyHubs.ReferralService.Shared/FamilyHubs.ReferralService.Shared.csproj
@@ -4,10 +4,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <VersionPrefix>1.1.4</VersionPrefix>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Title>FamilyHubs.ReferralService.Shared</Title>
-    <Description>FamilyHubs.ReferralService.Shared holds code that is shared between the API and UI</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/shared/service-directory-shared/src/FamilyHubs.ServiceDirectory.Shared/FamilyHubs.ServiceDirectory.Shared.csproj
+++ b/src/shared/service-directory-shared/src/FamilyHubs.ServiceDirectory.Shared/FamilyHubs.ServiceDirectory.Shared.csproj
@@ -4,10 +4,8 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <VersionPrefix>8.12.0</VersionPrefix>
-	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-	  <NoWarn>1701;1702;S1135</NoWarn>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;S1135</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/shared/shared-kernel/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/shared/shared-kernel/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -5,22 +5,6 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>EntityFrameworkCore.DataEncryption</AssemblyName>
 		<RootNamespace>Microsoft.EntityFrameworkCore.DataEncryption</RootNamespace>
-		<IsPackable>true</IsPackable>
-		<Version>4.0.1</Version>
-		<Authors>Filipe GOMES PEIXOTO</Authors>
-		<PackageId>EntityFrameworkCore.DataEncryption</PackageId>
-		<PackageProjectUrl>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption.git</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<PackageTags>entity-framework-core, extensions, dotnet-core, dotnet, encryption, fluent-api</PackageTags>
-		<PackageIcon>icon.png</PackageIcon>
-		<Copyright>Filipe GOMES PEIXOTO © 2019 - 2023</Copyright>
-		<Description>A plugin for Microsoft.EntityFrameworkCore to add support of encrypted fields using built-in or custom encryption providers.</Description>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageReleaseNotes>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption/releases/tag/v4.0.1</PackageReleaseNotes>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>2.4.0</VersionPrefix>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ui/connect-dashboard-ui/src/FamilyHubs.RequestForSupport.Core/FamilyHubs.RequestForSupport.Core.csproj
+++ b/src/ui/connect-dashboard-ui/src/FamilyHubs.RequestForSupport.Core/FamilyHubs.RequestForSupport.Core.csproj
@@ -12,12 +12,15 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FamilyHubs.ReferralService.Shared" Version="1.0.15" />
-		<PackageReference Include="FamilyHubs.SharedKernel" Version="2.3.0" />
 		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.23.0.88079">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\shared\referral-shared\src\FamilyHubs.ReferralService.Shared\FamilyHubs.ReferralService.Shared.csproj" />
+	  <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
@@ -13,9 +13,6 @@
   </ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="FamilyHubs.ReferralService.Shared" Version="1.1.5" />
-	  <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.12.0" />
-	  <PackageReference Include="FamilyHubs.SharedKernel" Version="2.3.2" />
 	  <PackageReference Include="libphonenumber-csharp" Version="8.13.39" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.15" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
@@ -24,5 +21,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\shared\referral-shared\src\FamilyHubs.ReferralService.Shared\FamilyHubs.ReferralService.Shared.csproj" />
+	  <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
+	  <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/FamilyHubs.Referral.Web.csproj
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/FamilyHubs.Referral.Web.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Enums.NET" Version="4.0.1" />
     <PackageReference Include="FamilyHubs.Notification.Api.Client" Version="1.1.1" />
-    <PackageReference Include="FamilyHubs.ReferralService.Shared" Version="1.1.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
@@ -47,6 +46,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\shared\referral-shared\src\FamilyHubs.ReferralService.Shared\FamilyHubs.ReferralService.Shared.csproj" />
 	  <ProjectReference Include="..\FamilyHubs.Referral.Core\FamilyHubs.Referral.Core.csproj" />
 	  <ProjectReference Include="..\FamilyHubs.Referral.Infrastructure\FamilyHubs.Referral.Infrastructure.csproj" />
 	</ItemGroup>

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Core/FamilyHubs.ServiceDirectory.Core.csproj
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Core/FamilyHubs.ServiceDirectory.Core.csproj
@@ -16,12 +16,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.12.0" />
-	  <PackageReference Include="FamilyHubs.SharedKernel" Version="2.3.1" />
 	  <PackageReference Include="SonarAnalyzer.CSharp" Version="9.25.0.90414">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
+	  <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Infrastructure/FamilyHubs.ServiceDirectory.Infrastructure.csproj
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Infrastructure/FamilyHubs.ServiceDirectory.Infrastructure.csproj
@@ -16,7 +16,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="FamilyHubs.SharedKernel" Version="2.3.1" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.15" />
@@ -28,6 +27,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
 	  <ProjectReference Include="..\FamilyHubs.ServiceDirectory.Core\FamilyHubs.ServiceDirectory.Core.csproj" />
 	</ItemGroup>
 

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/FamilyHubs.ServiceDirectory.Web.csproj
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/FamilyHubs.ServiceDirectory.Web.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="7.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="7.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="7.0.0" />
-    <PackageReference Include="FamilyHubs.SharedKernel" Version="2.3.1" />
     <PackageReference Include="FamilyHubs.SharedKernel.Razor" Version="9.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Serilog" Version="3.0.1" />
@@ -41,6 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
     <ProjectReference Include="..\FamilyHubs.ServiceDirectory.Core\FamilyHubs.ServiceDirectory.Core.csproj" />
     <ProjectReference Include="..\FamilyHubs.ServiceDirectory.Infrastructure\FamilyHubs.ServiceDirectory.Infrastructure.csproj" />
   </ItemGroup>

--- a/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.Core/ApiClient/ServiceDirectoryClient.cs
+++ b/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.Core/ApiClient/ServiceDirectoryClient.cs
@@ -6,7 +6,7 @@ namespace FamilyHubs.Idams.Maintenance.Core.ApiClient;
 
 public interface IServiceDirectoryClient
 {
-    Task<OrganisationWithServicesDto?> GetOrganisationById(long id);
+    Task<OrganisationDetailsDto?> GetOrganisationById(long id);
     Task<List<OrganisationDto>> GetOrganisations(CancellationToken cancellationToken = default);
 }
 
@@ -20,7 +20,7 @@ public class ServiceDirectoryClient : ApiService<ServiceDirectoryClient>, IServi
         _cacheService = cacheService;
     }
 
-    public async Task<OrganisationWithServicesDto?> GetOrganisationById(long id)
+    public async Task<OrganisationDetailsDto?> GetOrganisationById(long id)
     {
         var request = new HttpRequestMessage();
         request.Method = HttpMethod.Get;
@@ -31,7 +31,7 @@ public class ServiceDirectoryClient : ApiService<ServiceDirectoryClient>, IServi
         response.EnsureSuccessStatusCode();
 
         Logger.LogInformation($"{nameof(ServiceDirectoryClient)} Returning Organisation");
-        return await DeserializeResponse<OrganisationWithServicesDto>(response);
+        return await DeserializeResponse<OrganisationDetailsDto>(response);
     }
 
     public async Task<List<OrganisationDto>> GetOrganisations(CancellationToken cancellationToken = default)

--- a/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.Core/FamilyHubs.Idams.Maintenance.Core.csproj
+++ b/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.Core/FamilyHubs.Idams.Maintenance.Core.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FamilyHubs.ReferralService.Shared" Version="1.0.15" />
-    <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="2.0.6" />
     <PackageReference Include="FamilyHubs.SharedKernel.Razor" Version="9.1.5" />
     <PackageReference Include="FluentValidation" Version="11.7.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
@@ -16,6 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\referral-shared\src\FamilyHubs.ReferralService.Shared\FamilyHubs.ReferralService.Shared.csproj" />
+    <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
     <ProjectReference Include="..\FamilyHubs.Idams.Maintenance.Data\FamilyHubs.Idams.Maintenance.Data.csproj" />
   </ItemGroup>
 

--- a/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.Data/FamilyHubs.Idams.Maintenance.Data.csproj
+++ b/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.Data/FamilyHubs.Idams.Maintenance.Data.csproj
@@ -8,9 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.1.1" />
-    <PackageReference Include="FamilyHubs.SharedKernel" Version="2.0.51" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.14" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.UI/Pages/Welcome.cshtml.cs
+++ b/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.UI/Pages/Welcome.cshtml.cs
@@ -5,7 +5,6 @@ using FamilyHubs.Idams.Maintenance.UI.Pages.Shared;
 using FamilyHubs.ServiceDirectory.Shared.Dto;
 using FamilyHubs.SharedKernel.Identity;
 using FamilyHubs.SharedKernel.Identity.Models;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FamilyHubs.Idams.Maintenance.UI.Pages;
@@ -79,7 +78,7 @@ public void OnGet()
 
         if (await _cacheService.RetrieveOrganisationWithService() == null)
         {
-            OrganisationWithServicesDto? organisation = null;
+            OrganisationDetailsDto? organisation = null;
 
             if (long.TryParse(FamilyHubsUser.OrganisationId, out var organisationId))
             {

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Core/FamilyHubs.ServiceDirectory.Admin.Core.csproj
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Core/FamilyHubs.ServiceDirectory.Admin.Core.csproj
@@ -21,9 +21,6 @@
     <PackageReference Include="AspNetCore.HealthChecks.OpenIdConnectServer" Version="7.0.0" />
     <PackageReference Include="FamilyHubs.Notification.Api.Client" Version="1.1.1" />
     <PackageReference Include="FamilyHubs.Notification.Api.Contracts" Version="1.0.3" />
-    <PackageReference Include="FamilyHubs.ReferralService.Shared" Version="1.0.15" />
-    <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.11.0" />
-    <PackageReference Include="FamilyHubs.SharedKernel" Version="2.4.0" />
     <PackageReference Include="FamilyHubs.SharedKernel.Razor" Version="9.3.1" />
 	<PackageReference Include="libphonenumber-csharp" Version="8.13.36" />
 	<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="7.0.18" />
@@ -31,6 +28,12 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\referral-shared\src\FamilyHubs.ReferralService.Shared\FamilyHubs.ReferralService.Shared.csproj" />
+    <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
+    <ProjectReference Include="..\..\..\..\shared\shared-kernel\src\fh-shared-kernel.shared-kernel\FamilyHubs.SharedKernel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/FamilyHubs.ServiceDirectory.Admin.Web.csproj
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/FamilyHubs.ServiceDirectory.Admin.Web.csproj
@@ -25,7 +25,6 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.11.0" />
     <PackageReference Include="FamilyHubs.SharedKernel.Razor" Version="9.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
@@ -48,6 +47,7 @@
     <None Include="Pages\Error\500.cshtml" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\service-directory-shared\src\FamilyHubs.ServiceDirectory.Shared\FamilyHubs.ServiceDirectory.Shared.csproj" />
     <ProjectReference Include="..\FamilyHubs.ServiceDirectory.Admin.Core\FamilyHubs.ServiceDirectory.Admin.Core.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/FHB-365

- Update projects using FamilyHubs.SharedKernel to project references
- Update projects using FamilyHubs.ReferralService.Shared to project references
- Update projects using FamilyHubs.ServiceDirectory.Shared to project references

Note: EntityFrameworkCore.DataEncryption was a package but referenced by project so just removed the package details.