### PR TITLE
FHB-548 : Shared Kernel

### DIFF
--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Accessibility.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Accessibility.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Accessibility
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("location_id")]
+    [JsonIgnore]
+    public Guid? LocationId { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("details")]
+    public string? Details { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Address.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Address.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Address
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("location_id")]
+    [JsonIgnore]
+    public Guid? LocationId { get; init; }
+
+    [JsonPropertyName("attention")]
+    public string? Attention { get; init; }
+
+    [JsonPropertyName("address_1")]
+    public required string Address1 { get; init; }
+
+    [JsonPropertyName("address_2")]
+    public string? Address2 { get; init; }
+
+    [JsonPropertyName("city")]
+    public required string City { get; init; }
+
+    [JsonPropertyName("region")]
+    public string? Region { get; init; }
+
+    [JsonPropertyName("state_province")]
+    public required string StateProvince { get; init; }
+
+    [JsonPropertyName("postal_code")]
+    public required string PostalCode { get; init; }
+
+    [JsonPropertyName("country")]
+    public required string Country { get; init; }
+
+    [JsonPropertyName("address_type")]
+    public required string AddressType { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Attribute.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Attribute.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Attribute
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("link_id")]
+    [JsonIgnore]
+    public Guid LinkId { get; init; }
+
+    [JsonPropertyName("taxonomy_term_id")]
+    [JsonIgnore]
+    public Guid TaxonomyTermId { get; init; }
+
+    [JsonPropertyName("link_type")]
+    public string? LinkType { get; init; }
+
+    [JsonPropertyName("link_entity")]
+    public required string LinkEntity { get; init; }
+
+    [JsonPropertyName("value")]
+    public string? Value { get; init; }
+
+    [JsonPropertyName("taxonomy_term")]
+    [NotMapped]
+    public TaxonomyTerm? TaxonomyTerm { get; init; }
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Contact.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Contact.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Contact
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("organization_id")]
+    [JsonIgnore]
+    public Guid? OrganizationId { get; init; }
+
+    [JsonPropertyName("service_id")]
+    [JsonIgnore]
+    public Guid? ServiceId { get; init; }
+
+    [JsonPropertyName("service_at_location_id")]
+    [JsonIgnore]
+    public Guid? ServiceAtLocationId { get; init; }
+
+    [JsonPropertyName("location_id")]
+    [JsonIgnore]
+    public Guid? LocationId { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("department")]
+    public string? Department { get; init; }
+
+    [JsonPropertyName("email")]
+    public string? Email { get; init; }
+
+    [JsonPropertyName("phones")]
+    [NotMapped]
+    public List<Phone> Phones { get; init; } = new();
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/CostOption.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/CostOption.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class CostOption
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("service_id")]
+    [JsonIgnore]
+    public Guid ServiceId { get; init; }
+
+    [JsonPropertyName("valid_from")]
+    public DateTime? ValidFrom { get; init; } // TODO: .NET 8 supports native DateOnly, so convert.
+
+    [JsonPropertyName("valid_to")]
+    public DateTime? ValidTo { get; init; } // TODO: .NET 8 supports native DateOnly, so convert.
+
+    [JsonPropertyName("option")]
+    public string? Option { get; init; }
+
+    [JsonPropertyName("currency")]
+    public string? Currency { get; init; }
+
+    [JsonPropertyName("amount")]
+    public decimal? Amount { get; init; }
+
+    [JsonPropertyName("amount_description")]
+    public string? AmountDescription { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Funding.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Funding.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Funding
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("organization_id")]
+    [JsonIgnore]
+    public Guid? OrganizationId { get; init; }
+
+    [JsonPropertyName("service_id")]
+    [JsonIgnore]
+    public Guid? ServiceId { get; init; }
+
+    [JsonPropertyName("source")]
+    public string? Source { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Language.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Language.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Language
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("service_id")]
+    [JsonIgnore]
+    public Guid? ServiceId { get; init; }
+
+    [JsonPropertyName("location_id")]
+    [JsonIgnore]
+    public Guid? LocationId { get; init; }
+
+    [JsonPropertyName("phone_id")]
+    [JsonIgnore]
+    public Guid? PhoneId { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("code")]
+    public string? Code { get; init; }
+
+    [JsonPropertyName("note")]
+    public string? Note { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Location.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Location.cs
@@ -1,0 +1,76 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Location
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("location_type")]
+    public required string LocationType { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    [JsonPropertyName("organization_id")]
+    [JsonIgnore]
+    public Guid? OrganizationId { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("alternate_name")]
+    public string? AlternateName { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("transportation")]
+    public string? Transportation { get; init; }
+
+    [JsonPropertyName("latitude")]
+    public decimal? Latitude { get; init; }
+
+    [JsonPropertyName("longitude")]
+    public decimal? Longitude { get; init; }
+
+    [JsonPropertyName("external_identifier")]
+    public string? ExternalIdentifier { get; init; }
+
+    [JsonPropertyName("external_identifier_type")]
+    public string? ExternalIdentifierType { get; init; }
+
+    [JsonPropertyName("languages")]
+    [NotMapped]
+    public List<Language> Languages { get; init; } = new();
+
+    [JsonPropertyName("addresses")]
+    [NotMapped]
+    public List<Address> Addresses { get; init; } = new();
+
+    [JsonPropertyName("contacts")]
+    [NotMapped]
+    public List<Contact> Contacts { get; init; } = new();
+
+    [JsonPropertyName("accessibility")]
+    [NotMapped]
+    public List<Accessibility> Accessibility { get; init; } = new();
+
+    [JsonPropertyName("phones")]
+    [NotMapped]
+    public List<Phone> Phones { get; init; } = new();
+
+    [JsonPropertyName("schedules")]
+    [NotMapped]
+    public List<Schedule> Schedules { get; init; } = new();
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/MetaTableDescription.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/MetaTableDescription.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class MetaTableDescription
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("language")]
+    public string? Language { get; init; }
+
+    [JsonPropertyName("character_set")]
+    public string? CharacterSet { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Metadata.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Metadata.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Metadata
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("resource_id")]
+    [JsonIgnore]
+    public Guid ResourceId { get; init; }
+
+    [JsonPropertyName("resource_type")]
+    public required string ResourceType { get; init; }
+
+    [JsonPropertyName("last_action_date")]
+    public required DateTime LastActionDate { get; init; }
+
+    [JsonPropertyName("last_action_type")]
+    public required string LastActionType { get; init; }
+
+    [JsonPropertyName("field_name")]
+    public required string FieldName { get; init; }
+
+    [JsonPropertyName("previous_value")]
+    public required string PreviousValue { get; init; }
+
+    [JsonPropertyName("replacement_value")]
+    public required string ReplacementValue { get; init; }
+
+    [JsonPropertyName("updated_by")]
+    public required string UpdatedBy { get; init; }
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Organization.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Organization.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Organization
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("alternate_name")]
+    public string? AlternateName { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("email")]
+    public string? Email { get; init; }
+
+    [JsonPropertyName("website")]
+    public string? Website { get; init; }
+
+    [JsonPropertyName("year_incorporated")]
+    public required short YearIncorporated { get; init; }
+
+    [JsonPropertyName("legal_status")]
+    public required string LegalStatus { get; init; }
+
+    [JsonPropertyName("logo")]
+    public string? Logo { get; init; }
+
+    [JsonPropertyName("uri")]
+    public string? Uri { get; init; }
+
+    [JsonPropertyName("parent_organization_id")]
+    public Guid? ParentOrganizationId { get; init; }
+
+    [JsonPropertyName("funding")]
+    [NotMapped]
+    public List<Funding> Funding { get; init; } = new();
+
+    [JsonPropertyName("contacts")]
+    [NotMapped]
+    public List<Contact> Contacts { get; init; } = new();
+
+    [JsonPropertyName("phones")]
+    [NotMapped]
+    public List<Phone> Phones { get; init; } = new();
+
+    [JsonPropertyName("locations")]
+    [NotMapped]
+    public List<Location> Locations { get; init; } = new();
+
+    [JsonPropertyName("programs")]
+    [NotMapped]
+    public List<Program> Programs { get; init; } = new();
+
+    [JsonPropertyName("organization_identifiers")]
+    [NotMapped]
+    public List<OrganizationIdentifier> OrganizationIdentifiers { get; init; } = new();
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/OrganizationIdentifier.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/OrganizationIdentifier.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class OrganizationIdentifier
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("organization_id")]
+    [JsonIgnore]
+    public Guid? OrganizationId { get; init; }
+
+    [JsonPropertyName("identifier_scheme")]
+    public string? IdentifierScheme { get; init; }
+
+    [JsonPropertyName("identifier_type")]
+    public string? IdentifierType { get; init; }
+
+    [JsonPropertyName("identifier")]
+    public string? Identifier { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Phone.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Phone.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Phone
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("location_id")]
+    [JsonIgnore]
+    public Guid? LocationId { get; init; }
+
+    [JsonPropertyName("service_id")]
+    [JsonIgnore]
+    public Guid? ServiceId { get; init; }
+
+    [JsonPropertyName("organization_id")]
+    [JsonIgnore]
+    public Guid? OrganizationId { get; init; }
+
+    [JsonPropertyName("contact_id")]
+    [JsonIgnore]
+    public Guid? ContactId { get; init; }
+
+    [JsonPropertyName("service_at_location_id")]
+    [JsonIgnore]
+    public Guid? ServiceAtLocationId { get; init; }
+
+    [JsonPropertyName("number")]
+    public required string Number { get; init; }
+
+    [JsonPropertyName("extension")]
+    public short? Extension { get; init; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("languages")]
+    [NotMapped]
+    public List<Language> Languages { get; init; } = new();
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Program.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Program.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Program
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("organization_id")]
+    [JsonIgnore]
+    public Guid? OrganizationId { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("alternate_name")]
+    public string? AlternateName { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/RequiredDocument.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/RequiredDocument.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class RequiredDocument
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("service_id")]
+    [JsonIgnore]
+    public Guid? ServiceId { get; init; }
+
+    [JsonPropertyName("document")]
+    public string? Document { get; init; }
+
+    [JsonPropertyName("uri")]
+    public string? Uri { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Schedule.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Schedule.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Schedule
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("service_id")]
+    [JsonIgnore]
+    public Guid? ServiceId { get; init; }
+
+    [JsonPropertyName("location_id")]
+    [JsonIgnore]
+    public Guid? LocationId { get; init; }
+
+    [JsonPropertyName("service_at_location_id")]
+    [JsonIgnore]
+    public Guid? ServiceAtLocationId { get; init; }
+
+    [JsonPropertyName("valid_from")]
+    public DateTime? ValidFrom { get; init; }
+
+    [JsonPropertyName("valid_to")]
+    public DateTime? ValidTo { get; init; }
+
+    [JsonPropertyName("dtstart")]
+    public DateTime? Dtstart { get; init; }
+
+    [JsonPropertyName("timezone")]
+    public byte? Timezone { get; init; }
+
+    [JsonPropertyName("until")]
+    public DateTime? Until { get; init; }
+
+    [JsonPropertyName("count")]
+    public short? Count { get; init; }
+
+    [JsonPropertyName("wkst")]
+    public string? Wkst { get; init; }
+
+    [JsonPropertyName("freq")]
+    public string? Freq { get; init; }
+
+    [JsonPropertyName("interval")]
+    public short? Interval { get; init; }
+
+    [JsonPropertyName("byday")]
+    public string? Byday { get; init; }
+
+    [JsonPropertyName("byweekno")]
+    public string? Byweekno { get; init; }
+
+    [JsonPropertyName("bymonthday")]
+    public string? Bymonthday { get; init; }
+
+    [JsonPropertyName("byyearday")]
+    public string? Byyearday { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("opens_at")]
+    public TimeSpan? OpensAt { get; init; } // TODO: // TODO: .NET 8 supports native TimeOnly, so convert.
+
+    [JsonPropertyName("closes_at")]
+    public TimeSpan? ClosesAt { get; init; } // TODO: .NET 8 supports native TimeOnly, so convert.
+
+    [JsonPropertyName("schedule_link")]
+    public string? ScheduleLink { get; init; }
+
+    [JsonPropertyName("attending_type")]
+    public string? AttendingType { get; init; }
+
+    [JsonPropertyName("notes")]
+    public string? Notes { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Service.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Service.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Service
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("organization_id")]
+    [JsonIgnore]
+    public Guid OrganizationId { get; init; }
+
+    [JsonPropertyName("program_id")]
+    [JsonIgnore]
+    public Guid ProgramId { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("alternate_name")]
+    public string? AlternateName { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    [JsonPropertyName("email")]
+    public string? Email { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("interpretation_services")]
+    public string? InterpretationServices { get; init; }
+
+    [JsonPropertyName("application_process")]
+    public string? ApplicationProcess { get; init; }
+
+    [JsonPropertyName("fees_description")]
+    public string? FeesDescription { get; init; }
+
+    [JsonPropertyName("accreditations")]
+    public string? Accreditations { get; init; }
+
+    [JsonPropertyName("eligibility_description")]
+    public string? EligibilityDescription { get; init; }
+
+    [JsonPropertyName("minimum_age")]
+    public byte MinimumAge { get; init; }
+
+    [JsonPropertyName("maximum_age")]
+    public byte MaximumAge { get; init; }
+
+    [JsonPropertyName("assured_date")]
+    public DateTime? AssuredDate { get; init; }
+
+    [JsonPropertyName("assurer_email")]
+    public string? AssurerEmail { get; init; }
+
+    [JsonPropertyName("alert")]
+    public string? Alert { get; init; }
+
+    [JsonPropertyName("last_modified")]
+    public DateTime? LastModified { get; init; }
+
+    [JsonPropertyName("phones")]
+    [NotMapped]
+    public List<Phone> Phones { get; init; } = new();
+
+    [JsonPropertyName("schedules")]
+    [NotMapped]
+    public List<Schedule> Schedules { get; init; } = new();
+
+    [JsonPropertyName("service_areas")]
+    [NotMapped]
+    public List<ServiceArea> ServiceAreas { get; init; } = new();
+
+    [JsonPropertyName("service_at_locations")]
+    [NotMapped]
+    public List<ServiceAtLocation> ServiceAtLocations { get; init; } = new();
+
+    [JsonPropertyName("languages")]
+    [NotMapped]
+    public List<Language> Languages { get; init; } = new();
+
+    [JsonPropertyName("organization")]
+    [NotMapped]
+    public Organization? Organization { get; init; }
+
+    [JsonPropertyName("funding")]
+    [NotMapped]
+    public List<Funding> Funding { get; init; } = new();
+
+    [JsonPropertyName("cost_options")]
+    [NotMapped]
+    public List<CostOption> CostOptions { get; init; } = new();
+
+    [JsonPropertyName("program")]
+    [NotMapped]
+    public Program? Program { get; init; }
+
+    [JsonPropertyName("required_documents")]
+    [NotMapped]
+    public List<RequiredDocument> RequiredDocuments { get; init; } = new();
+
+    [JsonPropertyName("contacts")]
+    [NotMapped]
+    public List<Contact> Contacts { get; init; } = new();
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/ServiceArea.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/ServiceArea.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class ServiceArea
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("service_id")]
+    [JsonIgnore]
+    public Guid? ServiceId { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("extent")]
+    public string? Extent { get; init; }
+
+    [JsonPropertyName("extent_type")]
+    public string? ExtentType { get; init; }
+
+    [JsonPropertyName("uri")]
+    public string? Uri { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/ServiceAtLocation.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/ServiceAtLocation.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class ServiceAtLocation
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("service_id")]
+    [JsonIgnore]
+    public Guid? ServiceId { get; init; }
+
+    [JsonPropertyName("location_id")]
+    [JsonIgnore]
+    public Guid? LocationId { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("contacts")]
+    [NotMapped]
+    public List<Contact> Contacts { get; init; } = new();
+
+    [JsonPropertyName("phones")]
+    [NotMapped]
+    public List<Phone> Phones { get; init; } = new();
+
+    [JsonPropertyName("schedules")]
+    [NotMapped]
+    public List<Schedule> Schedules { get; init; } = new();
+
+    [JsonPropertyName("location")]
+    [NotMapped]
+    public Location? Location { get; init; }
+
+    [JsonPropertyName("attributes")]
+    [NotMapped]
+    public List<Attribute> Attributes { get; init; } = new();
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Taxonomy.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Taxonomy.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class Taxonomy
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("uri")]
+    public string? Uri { get; init; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/TaxonomyTerm.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/TaxonomyTerm.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
+
+public class TaxonomyTerm
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("code")]
+    public required string Code { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("parent_id")]
+    public Guid? ParentId { get; init; }
+
+    [JsonPropertyName("taxonomy")]
+    public string? Taxonomy { get; init; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+
+    [JsonPropertyName("taxonomy_detail")]
+    [NotMapped]
+    public Taxonomy? TaxonomyDetail { get; init; }
+
+    [JsonPropertyName("language")]
+    public string? Language { get; init; }
+
+    [JsonPropertyName("taxonomy_id")]
+    [JsonIgnore]
+    public Guid? TaxonomyId { get; init; }
+
+    [JsonPropertyName("term_uri")]
+    public string? TermUri { get; init; }
+
+    [JsonPropertyName("metadata")]
+    [NotMapped]
+    public List<Metadata> Metadata { get; init; } = new();
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
@@ -1,0 +1,259 @@
+using FamilyHubs.SharedKernel.OpenReferral.Entities;
+using Microsoft.EntityFrameworkCore;
+using Attribute = FamilyHubs.SharedKernel.OpenReferral.Entities.Attribute;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Repository;
+
+public class OpenReferralDbContextExtension
+{
+    public void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Table Mapping
+
+        modelBuilder.Entity<Accessibility>(entity =>
+        {
+            entity.ToTable("Accessibility", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Url).HasMaxLength(2048);
+        });
+
+        modelBuilder.Entity<Address>(entity =>
+        {
+            entity.ToTable("Address", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Attention).HasMaxLength(255);
+            entity.Property(e => e.Address1).HasMaxLength(255);
+            entity.Property(e => e.Address2).HasMaxLength(255);
+            entity.Property(e => e.City).HasMaxLength(255);
+            entity.Property(e => e.Region).HasMaxLength(255);
+            entity.Property(e => e.StateProvince).HasMaxLength(255);
+            entity.Property(e => e.PostalCode).HasMaxLength(255);
+            entity.Property(e => e.Country).HasMaxLength(255);
+            entity.Property(e => e.AddressType).HasMaxLength(255);
+        });
+
+        modelBuilder.Entity<Attribute>(entity =>
+        {
+            entity.ToTable("Attribute", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.LinkId).IsRequired();
+            entity.Property(e => e.TaxonomyTermId).IsRequired();
+            entity.Property(e => e.LinkType).HasMaxLength(50);
+            entity.Property(e => e.LinkEntity).HasMaxLength(50);
+            entity.Property(e => e.Value).HasMaxLength(50);
+        });
+
+        modelBuilder.Entity<Contact>(entity =>
+        {
+            entity.ToTable("Contact", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.Title).HasMaxLength(255);
+            entity.Property(e => e.Department).HasMaxLength(255);
+            entity.Property(e => e.Email).HasMaxLength(255);
+        });
+
+        modelBuilder.Entity<CostOption>(entity =>
+        {
+            entity.ToTable("CostOption", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.ServiceId).IsRequired();
+            entity.Property(e => e.ValidFrom).HasColumnType("date");
+            entity.Property(e => e.ValidTo).HasColumnType("date");
+            entity.Property(e => e.Currency).HasColumnType("nchar(3)");
+            entity.Property(e => e.Amount).HasPrecision(18, 2);
+        });
+
+        modelBuilder.Entity<Funding>(entity =>
+        {
+            entity.ToTable("Funding", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+        });
+
+        modelBuilder.Entity<Language>(entity =>
+        {
+            entity.ToTable("Language", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.Code).HasMaxLength(50);
+        });
+
+        modelBuilder.Entity<Location>(entity =>
+        {
+            entity.ToTable("Location", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.LocationType).HasMaxLength(255);
+            entity.Property(e => e.LocationType).HasMaxLength(2048);
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.AlternateName).HasMaxLength(255);
+            entity.Property(e => e.Transportation).HasMaxLength(255);
+            entity.Property(e => e.Latitude).HasPrecision(18, 2);
+            entity.Property(e => e.Longitude).HasPrecision(18, 2);
+            entity.Property(e => e.ExternalIdentifier).HasMaxLength(255);
+            entity.Property(e => e.ExternalIdentifierType).HasMaxLength(255);
+        });
+
+        modelBuilder.Entity<Metadata>(entity =>
+        {
+            entity.ToTable("Metadata", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.ResourceId).IsRequired();
+            entity.Property(e => e.ResourceType).HasMaxLength(50);
+            entity.Property(e => e.LastActionDate).HasColumnType("date");
+            entity.Property(e => e.LastActionType).HasMaxLength(255);
+            entity.Property(e => e.FieldName).HasMaxLength(50);
+            entity.Property(e => e.UpdatedBy).HasMaxLength(255);
+        });
+
+        modelBuilder.Entity<MetaTableDescription>(entity =>
+        {
+            entity.ToTable("MetaTableDescription", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.Language).HasMaxLength(50);
+            entity.Property(e => e.CharacterSet).HasMaxLength(50);
+        });
+
+        modelBuilder.Entity<Organization>(entity =>
+        {
+            entity.ToTable("Organization", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.AlternateName).HasMaxLength(255);
+            entity.Property(e => e.Email).HasMaxLength(255);
+            entity.Property(e => e.Website).HasMaxLength(2048);
+            entity.Property(e => e.LegalStatus).HasMaxLength(255);
+            entity.Property(e => e.Logo).HasMaxLength(2048);
+            entity.Property(e => e.Uri).HasMaxLength(2048);
+        });
+
+        modelBuilder.Entity<OrganizationIdentifier>(entity =>
+        {
+            entity.ToTable("OrganizationIdentifier", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.IdentifierScheme).HasMaxLength(50);
+            entity.Property(e => e.IdentifierType).HasMaxLength(50);
+            entity.Property(e => e.Identifier).HasMaxLength(255);
+        });
+
+        modelBuilder.Entity<Phone>(entity =>
+        {
+            entity.ToTable("Phone", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Number).HasMaxLength(50);
+            entity.Property(e => e.Type).HasMaxLength(50);
+        });
+
+        modelBuilder.Entity<Program>(entity =>
+        {
+            entity.ToTable("Program", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.AlternateName).HasMaxLength(255);
+        });
+
+        modelBuilder.Entity<RequiredDocument>(entity =>
+        {
+            entity.ToTable("RequiredDocument", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Document).HasMaxLength(255);
+            entity.Property(e => e.Uri).HasMaxLength(2048);
+        });
+
+        modelBuilder.Entity<Schedule>(entity =>
+        {
+            entity.ToTable("Schedule", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.ValidFrom).HasColumnType("date");
+            entity.Property(e => e.ValidTo).HasColumnType("date");
+            entity.Property(e => e.Dtstart).HasMaxLength(50);
+            entity.Property(e => e.Until).HasMaxLength(50);
+            entity.Property(e => e.Wkst).HasMaxLength(50);
+            entity.Property(e => e.Freq).HasMaxLength(50);
+            entity.Property(e => e.Byday).HasMaxLength(255);
+            entity.Property(e => e.Byweekno).HasMaxLength(255);
+            entity.Property(e => e.Bymonthday).HasMaxLength(255);
+            entity.Property(e => e.Byyearday).HasMaxLength(255);
+            entity.Property(e => e.OpensAt).HasColumnType("time");
+            entity.Property(e => e.ClosesAt).HasColumnType("time");
+            entity.Property(e => e.ScheduleLink).HasMaxLength(2048);
+        });
+
+        modelBuilder.Entity<Service>(entity =>
+        {
+            entity.ToTable("Service", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.OrganizationId).IsRequired();
+            entity.Property(e => e.ProgramId).IsRequired();
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.AlternateName).HasMaxLength(255);
+            entity.Property(e => e.Url).HasMaxLength(2048);
+            entity.Property(e => e.Email).HasMaxLength(255);
+            entity.Property(e => e.Status).HasMaxLength(255);
+            entity.Property(e => e.InterpretationServices).HasMaxLength(512);
+            entity.Property(e => e.ApplicationProcess).HasMaxLength(512);
+            entity.Property(e => e.AssuredDate).HasColumnType("date");
+            entity.Property(e => e.AssurerEmail).HasMaxLength(255);
+            entity.Property(e => e.Alert).HasMaxLength(255);
+            entity.Property(e => e.LastModified).HasPrecision(7);
+        });
+
+        modelBuilder.Entity<ServiceArea>(entity =>
+        {
+            entity.ToTable("ServiceArea", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.Extent).HasMaxLength(255);
+            entity.Property(e => e.ExtentType).HasMaxLength(255);
+            entity.Property(e => e.Uri).HasMaxLength(2048);
+        });
+
+        modelBuilder.Entity<ServiceAtLocation>(entity =>
+        {
+            entity.ToTable("ServiceAtLocation", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+        });
+
+        modelBuilder.Entity<Taxonomy>(entity =>
+        {
+            entity.ToTable("Taxonomy", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.Uri).HasMaxLength(2048);
+            entity.Property(e => e.Version).HasMaxLength(50);
+        });
+
+        modelBuilder.Entity<TaxonomyTerm>(entity =>
+        {
+            entity.ToTable("TaxonomyTerm", schema: "deds");
+            entity.HasKey(e => e.Id).IsClustered(false);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.Code).HasMaxLength(255);
+            entity.Property(e => e.Name).HasMaxLength(255);
+            entity.Property(e => e.Taxonomy).HasMaxLength(255);
+            entity.Property(e => e.Version).HasMaxLength(50);
+            entity.Property(e => e.Language).HasMaxLength(50);
+            entity.Property(e => e.TermUri).HasMaxLength(2048);
+        });
+    }
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
@@ -12,7 +12,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Accessibility>(entity =>
         {
-            entity.ToTable("Accessibility", schema: "deds");
+            entity.ToTable(nameof(Accessibility), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Url).HasMaxLength(2048);
@@ -20,7 +20,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Address>(entity =>
         {
-            entity.ToTable("Address", schema: "deds");
+            entity.ToTable(nameof(Address), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Attention).HasMaxLength(255);
@@ -36,7 +36,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Attribute>(entity =>
         {
-            entity.ToTable("Attribute", schema: "deds");
+            entity.ToTable(nameof(Attribute), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.LinkId).IsRequired();
@@ -48,7 +48,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Contact>(entity =>
         {
-            entity.ToTable("Contact", schema: "deds");
+            entity.ToTable(nameof(Contact), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Name).HasMaxLength(255);
@@ -59,7 +59,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<CostOption>(entity =>
         {
-            entity.ToTable("CostOption", schema: "deds");
+            entity.ToTable(nameof(CostOption), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.ServiceId).IsRequired();
@@ -71,14 +71,14 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Funding>(entity =>
         {
-            entity.ToTable("Funding", schema: "deds");
+            entity.ToTable(nameof(Funding), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
         });
 
         modelBuilder.Entity<Language>(entity =>
         {
-            entity.ToTable("Language", schema: "deds");
+            entity.ToTable(nameof(Language), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Name).HasMaxLength(255);
@@ -87,7 +87,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Location>(entity =>
         {
-            entity.ToTable("Location", schema: "deds");
+            entity.ToTable(nameof(Location), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.LocationType).HasMaxLength(255);
@@ -103,7 +103,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Metadata>(entity =>
         {
-            entity.ToTable("Metadata", schema: "deds");
+            entity.ToTable(nameof(Metadata), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.ResourceId).IsRequired();
@@ -116,7 +116,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<MetaTableDescription>(entity =>
         {
-            entity.ToTable("MetaTableDescription", schema: "deds");
+            entity.ToTable(nameof(MetaTableDescription), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Name).HasMaxLength(255);
@@ -126,7 +126,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Organization>(entity =>
         {
-            entity.ToTable("Organization", schema: "deds");
+            entity.ToTable(nameof(Organization), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Name).HasMaxLength(255);
@@ -140,7 +140,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<OrganizationIdentifier>(entity =>
         {
-            entity.ToTable("OrganizationIdentifier", schema: "deds");
+            entity.ToTable(nameof(OrganizationIdentifier), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.IdentifierScheme).HasMaxLength(50);
@@ -150,7 +150,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Phone>(entity =>
         {
-            entity.ToTable("Phone", schema: "deds");
+            entity.ToTable(nameof(Phone), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Number).HasMaxLength(50);
@@ -159,7 +159,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Program>(entity =>
         {
-            entity.ToTable("Program", schema: "deds");
+            entity.ToTable(nameof(Program), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Name).HasMaxLength(255);
@@ -168,7 +168,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<RequiredDocument>(entity =>
         {
-            entity.ToTable("RequiredDocument", schema: "deds");
+            entity.ToTable(nameof(RequiredDocument), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Document).HasMaxLength(255);
@@ -177,7 +177,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Schedule>(entity =>
         {
-            entity.ToTable("Schedule", schema: "deds");
+            entity.ToTable(nameof(Schedule), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.ValidFrom).HasColumnType("date");
@@ -197,7 +197,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<Service>(entity =>
         {
-            entity.ToTable("Service", schema: "deds");
+            entity.ToTable(nameof(Service), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.OrganizationId).IsRequired();
@@ -217,7 +217,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<ServiceArea>(entity =>
         {
-            entity.ToTable("ServiceArea", schema: "deds");
+            entity.ToTable(nameof(ServiceArea), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Name).HasMaxLength(255);
@@ -228,14 +228,14 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<ServiceAtLocation>(entity =>
         {
-            entity.ToTable("ServiceAtLocation", schema: "deds");
+            entity.ToTable(nameof(ServiceAtLocation), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
         });
 
         modelBuilder.Entity<Taxonomy>(entity =>
         {
-            entity.ToTable("Taxonomy", schema: "deds");
+            entity.ToTable(nameof(Taxonomy), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Name).HasMaxLength(255);
@@ -245,7 +245,7 @@ public class OpenReferralDbContextExtension
 
         modelBuilder.Entity<TaxonomyTerm>(entity =>
         {
-            entity.ToTable("TaxonomyTerm", schema: "deds");
+            entity.ToTable(nameof(TaxonomyTerm), schema: "deds");
             entity.HasKey(e => e.Id).IsClustered(false);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.Code).HasMaxLength(255);


### PR DESCRIPTION
Ticket: [FHB-548](https://dfedigital.atlassian.net/browse/FHB-548)

---

This ticket is part of FHB-548. It creates the entities and the basic table mappings. I have tested this migration locally and it works.

Foreign key relationships will be handled as part of FHB-549 and so a further update to the shared kernel and another migration will be created for that.

The `[JsonIgnore]` properties also reflect what is returned in the schema, and mean that the service we get from the mock API deserializes into a fully embedded Service (implementation of this is also apart of 549).

[FHB-548]: https://dfedigital.atlassian.net/browse/FHB-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ