### PR TITLE
FHB-549 : Fix Table Naming into Shared Kernel (Continued)

### DIFF
--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>2.8.1</VersionPrefix>
+    <VersionPrefix>2.8.2</VersionPrefix>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
@@ -251,344 +251,344 @@ public static class OpenReferralDbContextExtension
         });
     }
 
-private static void CreateEntityAttributeRelationships(ModelBuilder modelBuilder)
-{
-    modelBuilder.Entity<Accessibility>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Accessibility) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+    private static void CreateEntityAttributeRelationships(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Accessibility>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Accessibility) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Address>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Address) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Address>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Address) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Contact>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Contact) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Contact>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Contact) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<CostOption>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(CostOption) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<CostOption>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(CostOption) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Funding>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Funding) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Funding>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Funding) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Language>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Language) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Language>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Language) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Location>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Location) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Location>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Location) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<MetaTableDescription>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(MetaTableDescription) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<MetaTableDescription>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(MetaTableDescription) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Organization>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Organization) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Organization>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Organization) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<OrganizationIdentifier>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(OrganizationIdentifier) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<OrganizationIdentifier>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(OrganizationIdentifier) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Phone>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Phone) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Phone>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Phone) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Program>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Program) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Program>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Program) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<RequiredDocument>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(RequiredDocument) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<RequiredDocument>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(RequiredDocument) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Schedule>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Schedule) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Schedule>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Schedule) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Service>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Service) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Service>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Service) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<ServiceArea>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(ServiceArea) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<ServiceArea>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(ServiceArea) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<ServiceAtLocation>()
-        .HasMany<Attribute>(e => e.Attributes)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(ServiceAtLocation) + nameof(Attribute) + "s");
-                e.Metadata.SetSchema(DedsMeta);
-            });
-}
+        modelBuilder.Entity<ServiceAtLocation>()
+            .HasMany<Attribute>(e => e.Attributes)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(ServiceAtLocation) + nameof(Attribute) + "s");
+                    e.Metadata.SetSchema(DedsMeta);
+                });
+    }
 
-private static void CreateEntityMetadataRelationships(ModelBuilder modelBuilder)
-{
-    modelBuilder.Entity<Accessibility>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Accessibility) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+    private static void CreateEntityMetadataRelationships(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Accessibility>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Accessibility) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Address>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Address) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Address>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Address) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Attribute>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Attribute) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Attribute>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Attribute) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Contact>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Contact) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Contact>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Contact) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<CostOption>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(CostOption) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<CostOption>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(CostOption) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Funding>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Funding) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Funding>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Funding) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Language>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Language) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Language>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Language) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Location>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Location) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Location>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Location) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<MetaTableDescription>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(MetaTableDescription) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<MetaTableDescription>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(MetaTableDescription) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Organization>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Organization) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Organization>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Organization) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<OrganizationIdentifier>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(OrganizationIdentifier) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<OrganizationIdentifier>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(OrganizationIdentifier) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Phone>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Program) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Phone>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Program) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Program>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Program) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Program>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Program) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<RequiredDocument>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(RequiredDocument) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<RequiredDocument>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(RequiredDocument) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Schedule>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Schedule) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Schedule>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Schedule) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Service>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Service) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Service>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Service) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<ServiceArea>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(ServiceArea) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<ServiceArea>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(ServiceArea) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<ServiceAtLocation>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(ServiceAtLocation) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<ServiceAtLocation>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(ServiceAtLocation) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<Taxonomy>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(Taxonomy) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
+        modelBuilder.Entity<Taxonomy>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(Taxonomy) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
 
-    modelBuilder.Entity<TaxonomyTerm>()
-        .HasMany<Metadata>(e => e.Metadata)
-        .WithMany().UsingEntity<Dictionary<string, object>>(
-            e =>
-            {
-                e.Metadata.SetTableName(nameof(TaxonomyTerm) + nameof(Metadata));
-                e.Metadata.SetSchema(DedsMeta);
-            });
-}
+        modelBuilder.Entity<TaxonomyTerm>()
+            .HasMany<Metadata>(e => e.Metadata)
+            .WithMany().UsingEntity<Dictionary<string, object>>(
+                e =>
+                {
+                    e.Metadata.SetTableName(nameof(TaxonomyTerm) + nameof(Metadata));
+                    e.Metadata.SetSchema(DedsMeta);
+                });
+    }
 
     private static void CreateOrganizationRelationships(ModelBuilder modelBuilder)
     {

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
@@ -251,196 +251,344 @@ public static class OpenReferralDbContextExtension
         });
     }
 
-    private static void CreateEntityAttributeRelationships(ModelBuilder modelBuilder)
-    {
-        modelBuilder.Entity<Accessibility>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+private static void CreateEntityAttributeRelationships(ModelBuilder modelBuilder)
+{
+    modelBuilder.Entity<Accessibility>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Accessibility) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Address>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Address>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Address) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Contact>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Contact>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Contact) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<CostOption>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<CostOption>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(CostOption) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Funding>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Funding>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Funding) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Language>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Language>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Language) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Location>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Location>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Location) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<MetaTableDescription>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<MetaTableDescription>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(MetaTableDescription) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Organization>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Organization>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Organization) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<OrganizationIdentifier>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<OrganizationIdentifier>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(OrganizationIdentifier) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Phone>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Phone>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Phone) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Program>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Program>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Program) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<RequiredDocument>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<RequiredDocument>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(RequiredDocument) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Schedule>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Schedule>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Schedule) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Service>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Service>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Service) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<ServiceArea>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<ServiceArea>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(ServiceArea) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<ServiceAtLocation>()
-            .HasMany<Attribute>(e => e.Attributes)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
-    }
+    modelBuilder.Entity<ServiceAtLocation>()
+        .HasMany<Attribute>(e => e.Attributes)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(ServiceAtLocation) + nameof(Attribute) + "s");
+                e.Metadata.SetSchema(DedsMeta);
+            });
+}
 
-    private static void CreateEntityMetadataRelationships(ModelBuilder modelBuilder)
-    {
-        modelBuilder.Entity<Accessibility>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+private static void CreateEntityMetadataRelationships(ModelBuilder modelBuilder)
+{
+    modelBuilder.Entity<Accessibility>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Accessibility) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Address>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Address>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Address) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Attribute>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Attribute>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Attribute) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Contact>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Contact>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Contact) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<CostOption>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<CostOption>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(CostOption) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Funding>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Funding>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Funding) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Language>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Language>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Language) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Location>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Location>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Location) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<MetaTableDescription>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<MetaTableDescription>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(MetaTableDescription) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Organization>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Organization>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Organization) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<OrganizationIdentifier>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<OrganizationIdentifier>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(OrganizationIdentifier) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Phone>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Phone>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Program) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Program>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Program>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Program) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<RequiredDocument>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<RequiredDocument>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(RequiredDocument) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Schedule>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Schedule>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Schedule) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Service>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Service>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Service) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<ServiceArea>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<ServiceArea>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(ServiceArea) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<ServiceAtLocation>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<ServiceAtLocation>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(ServiceAtLocation) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<Taxonomy>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
+    modelBuilder.Entity<Taxonomy>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(Taxonomy) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
 
-        modelBuilder.Entity<TaxonomyTerm>()
-            .HasMany<Metadata>(e => e.Metadata)
-            .WithMany().UsingEntity<Dictionary<string, object>>(
-                e => { e.Metadata.SetSchema(DedsMeta); });
-    }
+    modelBuilder.Entity<TaxonomyTerm>()
+        .HasMany<Metadata>(e => e.Metadata)
+        .WithMany().UsingEntity<Dictionary<string, object>>(
+            e =>
+            {
+                e.Metadata.SetTableName(nameof(TaxonomyTerm) + nameof(Metadata));
+                e.Metadata.SetSchema(DedsMeta);
+            });
+}
 
     private static void CreateOrganizationRelationships(ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
Ticket: [FHB-549](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/FHB/boards/245?selectedIssue=FHB-549)
Related Ticket: [FHB-548](https://dfedigital.atlassian.net.mcas.ms/browse/FHB-548)

--

PR for the core tables: https://github.com/DFE-Digital/fh-services/pull/115

--

This PR fixes an issue originating on `FHB-548` where the names of the tables aren't plurals. The Service Directory API will create a migration for this fix in a separate PR, as it needs to use the package first. 

In this case, the many-to-many tables for Attributes & Metadata were not being automatically generated as plurals, so I've manually added it.

The tables will be in the forms:

- AccessibilityAttributes
- ServiceAttributes
- ContactAttributes
- ...

---

- AccessibilityMetadata
- ServiceMetadata
- ContactMetadata
- ...

[FHB-549]: https://dfedigital.atlassian.net/browse/FHB-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FHB-548]: https://dfedigital.atlassian.net/browse/FHB-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ