### PR TITLE
FHB-549 : Fix Duplicate Table Name

### DIFF
--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>2.8.2</VersionPrefix>
+    <VersionPrefix>2.8.3</VersionPrefix>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
@@ -513,7 +513,7 @@ public static class OpenReferralDbContextExtension
             .WithMany().UsingEntity<Dictionary<string, object>>(
                 e =>
                 {
-                    e.Metadata.SetTableName(nameof(Program) + nameof(Metadata));
+                    e.Metadata.SetTableName(nameof(Phone) + nameof(Metadata));
                     e.Metadata.SetSchema(DedsMeta);
                 });
 


### PR DESCRIPTION
Accidentally had `PhoneMetadata` be called `ProgramMetadata`, which then conflicted with the actual `ProgramMetadata`. Have ensured that was the only error :)