### PR TITLE
FHB-549 : Remove Extra Column from Schema

### DIFF
--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>2.8.3</VersionPrefix>
+    <VersionPrefix>2.8.4</VersionPrefix>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/TaxonomyTerm.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/TaxonomyTerm.cs
@@ -19,9 +19,6 @@ public class TaxonomyTerm : BaseHsdsEntity
     [JsonPropertyName("taxonomy")]
     public string? Taxonomy { get; init; }
 
-    [JsonPropertyName("version")]
-    public string? Version { get; init; }
-
     [JsonPropertyName("language")]
     public string? Language { get; init; }
 

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Repository/OpenReferralDbContextExtension.cs
@@ -245,7 +245,6 @@ public static class OpenReferralDbContextExtension
             entity.Property(e => e.Code).HasMaxLength(255);
             entity.Property(e => e.Name).HasMaxLength(255);
             entity.Property(e => e.Taxonomy).HasMaxLength(255);
-            entity.Property(e => e.Version).HasMaxLength(50);
             entity.Property(e => e.Language).HasMaxLength(50);
             entity.Property(e => e.TermUri).HasMaxLength(2048);
         });


### PR DESCRIPTION
Ticket: [FHB-549](https://dfedigital.atlassian.net/browse/FHB-549)

This PR fixes a minor bug with the OR Schema in which `TaxonomyTerm` has a "Version" column, but neither the database schema or JSON schema has it.

Another PR will be made from the Service Directory API to generate the migration for this fix after this is merged.

---

Database Schema:
<img width="394" alt="Screenshot 2024-09-23 at 12 40 07 PM" src="https://github.com/user-attachments/assets/c8f22c4a-296e-47f6-933b-bfacad15ed0b">

---

JSON Schema:
<img width="350" alt="Screenshot 2024-09-23 at 12 40 53 PM" src="https://github.com/user-attachments/assets/92cfd399-9645-418b-a63d-7879a5e65287">


[FHB-549]: https://dfedigital.atlassian.net/browse/FHB-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ