### PR TITLE
FHB-549 : Migration to Remove Version Column

### DIFF
--- a/src/function/open-referral-function/src/FamilyHubs.OpenReferral.Function/FamilyHubs.OpenReferral.Function.csproj
+++ b/src/function/open-referral-function/src/FamilyHubs.OpenReferral.Function/FamilyHubs.OpenReferral.Function.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="FamilyHubs.SharedKernel" Version="2.8.3" />
+        <PackageReference Include="FamilyHubs.SharedKernel" Version="2.8.4" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/FamilyHubs.ServiceDirectory.Data.csproj
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/FamilyHubs.ServiceDirectory.Data.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="8.12.0" />
-		<PackageReference Include="FamilyHubs.SharedKernel" Version="2.8.3" />
+		<PackageReference Include="FamilyHubs.SharedKernel" Version="2.8.4" />
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.14" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="7.0.18" />

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20240923115745_RemoveVersionColumnFromDedsTaxonomyTerms.Designer.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20240923115745_RemoveVersionColumnFromDedsTaxonomyTerms.Designer.cs
@@ -4,6 +4,7 @@ using FamilyHubs.ServiceDirectory.Data.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
@@ -12,9 +13,11 @@ using NetTopologySuite.Geometries;
 namespace FamilyHubs.ServiceDirectory.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240923115745_RemoveVersionColumnFromDedsTaxonomyTerms")]
+    partial class RemoveVersionColumnFromDedsTaxonomyTerms
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20240923115745_RemoveVersionColumnFromDedsTaxonomyTerms.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20240923115745_RemoveVersionColumnFromDedsTaxonomyTerms.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FamilyHubs.ServiceDirectory.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveVersionColumnFromDedsTaxonomyTerms : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Version",
+                schema: "deds",
+                table: "TaxonomyTerms");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Version",
+                schema: "deds",
+                table: "TaxonomyTerms",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Ticket: [FHB-549](https://dfedigital.atlassian.net/browse/FHB-549)

Related PR: https://github.com/DFE-Digital/fh-services/pull/124

---

This PR adds the migration to remove the "Version" column from `[deds]` as explained in https://github.com/DFE-Digital/fh-services/pull/124, and updates the OR Function to use the same version.

[FHB-549]: https://dfedigital.atlassian.net/browse/FHB-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ