### PR TITLE
Fhb 671 delete service error page

### DIFF
--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/UrlKeys.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/UrlKeys.cs
@@ -4,5 +4,6 @@ public enum UrlKeys
 {
     ConnectWeb,
     ManageWeb, 
-    FindWeb
+    FindWeb,
+    ConnectSupportWeb
 }

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/UrlKeys.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/UrlKeys.cs
@@ -5,5 +5,5 @@ public enum UrlKeys
     ConnectWeb,
     ManageWeb, 
     FindWeb,
-    ConnectSupportWeb
+    DashboardWeb
 }

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml
@@ -13,7 +13,7 @@
         <p>@Model.ServiceModel?.Name cannot be deleted because there are outstanding connection requests.</p>
 
         <ul>
-            <li>manage these request yourself, if you have access, by <a href="@Html.FamilyHubUrl(UrlKeys.ConnectSupportWeb, "/La/Dashboard")" new-tab>going to the ‘My requests’ page on Connect</a></li>
+            <li>manage these request yourself, if you have access, by <a href="@Html.FamilyHubUrl(UrlKeys.DashboardWeb, "/La/Dashboard")" new-tab>going to the ‘My requests’ page on Connect</a></li>
             <li>find someone who can make and manage requests on Connect, by <a href="/AccountAdmin/ManagePermissions">checking your organisation’s list of users</a></li>
         </ul>
 

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml
@@ -1,0 +1,23 @@
+@page
+@using FamilyHubs.SharedKernel.Razor.Urls
+@model FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services.DeleteServiceErrorModel
+
+@{
+    ViewData["Title"] = "You cannot delete this service yet";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">@ViewData["Title"]</h1>
+
+        <p>@Model.ServiceModel?.Name cannot be deleted because there are outstanding connection requests.</p>
+
+        <ul>
+            <li>manage these request yourself, if you have access, by <a href="@Html.FamilyHubUrl(UrlKeys.ConnectSupportWeb, "/La/Dashboard")" new-tab>going to the ‘My requests’ page on Connect</a></li>
+            <li>find someone who can make and manage requests on Connect, by <a href="/AccountAdmin/ManagePermissions">checking your organisation’s list of users</a></li>
+        </ul>
+
+        <a class="govuk-button" asp-page="/Welcome">Go to homepage</a>
+    </div>
+
+</div>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml
@@ -10,7 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">@ViewData["Title"]</h1>
 
-        <p>@Model.ServiceModel?.Name cannot be deleted because there are outstanding connection requests.</p>
+        <p>@Model.ServiceName cannot be deleted because there are outstanding connection requests.</p>
 
         <ul>
             <li>manage these request yourself, if you have access, by <a href="@Html.FamilyHubUrl(UrlKeys.DashboardWeb, "/La/Dashboard")" new-tab>going to the ‘My requests’ page on Connect</a></li>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml.cs
@@ -1,0 +1,26 @@
+using FamilyHubs.ServiceDirectory.Admin.Core.DistributedCache;
+using FamilyHubs.ServiceDirectory.Admin.Core.Models.ServiceJourney;
+using FamilyHubs.SharedKernel.Identity;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
+
+[Authorize(Roles = RoleGroups.AdminRole)]
+public class DeleteServiceErrorModel : PageModel
+{
+    private readonly IRequestDistributedCache _connectionRequestCache;
+    public ServiceModel? ServiceModel { get; set; }
+
+    public DeleteServiceErrorModel(IRequestDistributedCache connectionRequestCache)
+    {
+        _connectionRequestCache = connectionRequestCache;
+    }
+
+    public async Task OnGetAsync()
+    {
+        var user = HttpContext.GetFamilyHubsUser();
+
+        ServiceModel = await _connectionRequestCache.GetAsync<ServiceModel>(user.Email);
+    }
+}

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml.cs
@@ -1,6 +1,4 @@
 using FamilyHubs.ServiceDirectory.Admin.Core.ApiClient;
-using FamilyHubs.ServiceDirectory.Admin.Core.DistributedCache;
-using FamilyHubs.ServiceDirectory.Admin.Core.Models.ServiceJourney;
 using FamilyHubs.SharedKernel.Identity;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 
-[Authorize(Roles = RoleGroups.AdminRole)]
+[Authorize(Roles = RoleGroups.LaManagerOrDualRole)]
 public class DeleteServiceErrorModel : PageModel
 {
     private readonly IRequestDistributedCache _connectionRequestCache;

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Delete-Service-Error.cshtml.cs
@@ -1,7 +1,9 @@
+using FamilyHubs.ServiceDirectory.Admin.Core.ApiClient;
 using FamilyHubs.ServiceDirectory.Admin.Core.DistributedCache;
 using FamilyHubs.ServiceDirectory.Admin.Core.Models.ServiceJourney;
 using FamilyHubs.SharedKernel.Identity;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
@@ -9,18 +11,21 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 [Authorize(Roles = RoleGroups.LaManagerOrDualRole)]
 public class DeleteServiceErrorModel : PageModel
 {
-    private readonly IRequestDistributedCache _connectionRequestCache;
-    public ServiceModel? ServiceModel { get; set; }
+    private readonly IServiceDirectoryClient _serviceDirectoryClient;
+    
+    public string ServiceName { get; set; } = string.Empty;
 
-    public DeleteServiceErrorModel(IRequestDistributedCache connectionRequestCache)
+    [BindProperty] public long ServiceId { get; set; }
+    
+    public DeleteServiceErrorModel(IServiceDirectoryClient serviceDirectoryClient)
     {
-        _connectionRequestCache = connectionRequestCache;
+        _serviceDirectoryClient = serviceDirectoryClient;
     }
 
-    public async Task OnGetAsync()
+    public async Task OnGetAsync(long serviceId)
     {
-        var user = HttpContext.GetFamilyHubsUser();
-
-        ServiceModel = await _connectionRequestCache.GetAsync<ServiceModel>(user.Email);
+        ServiceId = serviceId;
+        var service = await _serviceDirectoryClient.GetServiceById(ServiceId);
+        ServiceName = service.Name;
     }
 }

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -256,7 +256,7 @@
         @if (Model.Flow == JourneyFlow.Edit && Model.FamilyHubsUser.Role is RoleTypes.LaManager or RoleTypes.LaDualRole)
         {
             <h2 class="govuk-heading-m">Delete this service</h2>
-            <p class="govuk-!-margin-bottom-9">You can <a href="/manage-services/delete-service">delete this service</a> if you want to permanently remove it from the directory.</p>
+            <p class="govuk-!-margin-bottom-9">You can <a href="/manage-services/delete-service?serviceId=@Model.ServiceModel.Id">delete this service</a> if you want to permanently remove it from the directory.</p>
         }
 
         @if (Model.Flow != JourneyFlow.Edit || Model.ServiceModel!.Updated)

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -256,7 +256,7 @@
         @if (Model.Flow == JourneyFlow.Edit && Model.FamilyHubsUser.Role is RoleTypes.LaManager or RoleTypes.LaDualRole)
         {
             <h2 class="govuk-heading-m">Delete this service</h2>
-        <p class="govuk-!-margin-bottom-9">You can <a asp-page="/manage-services/delete-service" asp-route-serviceId="@Model.ServiceModel.Id">delete this service</a> if you want to permanently remove it from the directory.</p>
+            <p class="govuk-!-margin-bottom-9">You can <a asp-page="/manage-services/delete-service" asp-route-serviceId="@Model.ServiceModel.Id">delete this service</a> if you want to permanently remove it from the directory.</p>
         }
 
         @if (Model.Flow != JourneyFlow.Edit || Model.ServiceModel!.Updated)

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -256,7 +256,7 @@
         @if (Model.Flow == JourneyFlow.Edit && Model.FamilyHubsUser.Role is RoleTypes.LaManager or RoleTypes.LaDualRole)
         {
             <h2 class="govuk-heading-m">Delete this service</h2>
-            <p class="govuk-!-margin-bottom-9">You can <a href="/manage-services/delete-service?serviceId=@Model.ServiceModel.Id">delete this service</a> if you want to permanently remove it from the directory.</p>
+        <p class="govuk-!-margin-bottom-9">You can <a asp-page="/manage-services/delete-service" asp-route-serviceId="@Model.ServiceModel.Id">delete this service</a> if you want to permanently remove it from the directory.</p>
         }
 
         @if (Model.Flow != JourneyFlow.Edit || Model.ServiceModel!.Updated)

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/appsettings.json
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/appsettings.json
@@ -43,7 +43,7 @@
       "ManageWeb": "https://localhost:7216/",
       "FindWeb": "https://localhost:7199",
       "PostcodesIo": "https://api.postcodes.io/postcodes/",
-      "ConnectSupportWeb": "https://localhost:7166"
+      "DashboardWeb": "https://localhost:7166"
     },
     "HealthCheck": {
       "Enabled": true,

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/appsettings.json
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/appsettings.json
@@ -42,7 +42,8 @@
       "ConnectWeb": "https://localhost:7270/",
       "ManageWeb": "https://localhost:7216/",
       "FindWeb": "https://localhost:7199",
-      "PostcodesIo": "https://api.postcodes.io/postcodes/"
+      "PostcodesIo": "https://api.postcodes.io/postcodes/",
+      "ConnectSupportWeb": "https://localhost:7166"
     },
     "HealthCheck": {
       "Enabled": true,


### PR DESCRIPTION
This PR is adding in the Error page for when there are still open services.
- Add error page that will be used when there are no open connections.
- Added app settings to point to the other connect service on 1 of the links
Note:
-  Added dashboardweb url to general keyvaults