### PR TITLE
FHB-680 : Referral Shared

### DIFF
--- a/src/shared/referral-shared/src/FamilyHubs.ReferralService.Shared/Dto/OrganisationDto.cs
+++ b/src/shared/referral-shared/src/FamilyHubs.ReferralService.Shared/Dto/OrganisationDto.cs
@@ -12,14 +12,12 @@ namespace FamilyHubs.ReferralService.Shared.Dto;
 
 public record OrganisationDto : DtoBase<long>
 {
-    public long? ReferralServiceId { get; set; }
     public string? Name { get; set; }
     public string? Description { get; set; }
 
     public override int GetHashCode()
     {
         return
-            EqualityComparer<long?>.Default.GetHashCode(ReferralServiceId!) * -1521134295 +
             EqualityComparer<string>.Default.GetHashCode(Name) * -1521134295 +
             EqualityComparer<string?>.Default.GetHashCode(Description) * -1521134295
             ;
@@ -34,7 +32,6 @@ public record OrganisationDto : DtoBase<long>
             return true;
 
         return
-            EqualityComparer<long?>.Default.Equals(ReferralServiceId, other.ReferralServiceId) &&
             EqualityComparer<string>.Default.Equals(Name, other.Name) &&
             EqualityComparer<string?>.Default.Equals(Description, other.Description)
             ;

--- a/src/shared/referral-shared/src/FamilyHubs.ReferralService.Shared/FamilyHubs.ReferralService.Shared.csproj
+++ b/src/shared/referral-shared/src/FamilyHubs.ReferralService.Shared/FamilyHubs.ReferralService.Shared.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <VersionPrefix>1.1.4</VersionPrefix>
+	  <VersionPrefix>1.2.0</VersionPrefix>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>FamilyHubs.ReferralService.Shared</Title>
     <Description>FamilyHubs.ReferralService.Shared holds code that is shared between the API and UI</Description>


### PR DESCRIPTION
Ticket: [FHB-680](https://dfedigital.atlassian.net/browse/FHB-680)

---

This PR updates the Referral Shared library to no longer have the ReferralServiceId in the OrganisationDto, as the database Organisation object no longer has a ReferralServiceId and so this will always be null going forward.

[FHB-680]: https://dfedigital.atlassian.net/browse/FHB-680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ