### PR TITLE
FHB-735 : Check for Con. Req. only on Confirm

### DIFF
--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
@@ -74,12 +74,6 @@ public class DeleteService : PageModel
     public async Task<IActionResult> OnGetAsync(long serviceId)
     {
         ServiceId = serviceId;
-
-        if (await IsOpenConnectionRequests())
-        {
-            return RedirectToPage(OpenConnectionErrorUrl, new { serviceId = ServiceId });
-        }
-
         ServiceName = await GetServiceName();
 
         return Page();


### PR DESCRIPTION
Ticket: [FHB-735](https://dfedigital.atlassian.net.mcas.ms/browse/FHB-735)

---

FHB-735 removes the check for open connection requests when the page loads, so it only checks once the user has clicked "Confirm" after saying "Yes" to wanting to delete the service.

[FHB-735]: https://dfedigital.atlassian.net/browse/FHB-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ