### PR TITLE
FHB-669 / FHB-670 : VCS Manager + VCS Dual Role Delete

### DIFF
--- a/src/service/referral-api/src/FamilyHubs.Referral.Api/Endpoints/MinimalReferralEndPoints.cs
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Api/Endpoints/MinimalReferralEndPoints.cs
@@ -103,7 +103,7 @@ public class MinimalReferralEndPoints
         }).WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referral By Composite Keys") { Tags = new[] { "Referrals" } });
 
         app.MapGet("api/referral/count",
-            [Authorize(Roles = RoleGroups.LaManagerOrDualRole + "," + RoleTypes.DfeAdmin)]
+            [Authorize(Roles = RoleGroups.LaManagerOrDualRole + "," + RoleTypes.VcsManager + "," + RoleTypes.DfeAdmin)]
             async (long serviceId, CancellationToken cancellationToken, ISender mediator) =>
         {
             GetReferralCountByServiceIdCommand request = new(serviceId);

--- a/src/service/referral-api/src/FamilyHubs.Referral.Api/Endpoints/MinimalReferralEndPoints.cs
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Api/Endpoints/MinimalReferralEndPoints.cs
@@ -103,7 +103,7 @@ public class MinimalReferralEndPoints
         }).WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referral By Composite Keys") { Tags = new[] { "Referrals" } });
 
         app.MapGet("api/referral/count",
-            [Authorize(Roles = RoleGroups.LaManagerOrDualRole + "," + RoleTypes.VcsManager + "," + RoleTypes.DfeAdmin)]
+            [Authorize(Roles = RoleGroups.AdminRole)]
             async (long serviceId, CancellationToken cancellationToken, ISender mediator) =>
         {
             GetReferralCountByServiceIdCommand request = new(serviceId);

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalServiceEndPoints.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalServiceEndPoints.cs
@@ -144,7 +144,7 @@ public class MinimalServiceEndPoints
         }).WithMetadata(new SwaggerOperationAttribute("Create a Service", "Create a Service") { Tags = new[] { "Services" } });
         
         app.MapDelete("api/services/{id}",
-            [Authorize(Roles = $"{RoleTypes.DfeAdmin},{RoleTypes.LaManager},{RoleTypes.LaDualRole},{RoleTypes.VcsManager}")] async
+            [Authorize(Roles = RoleGroups.AdminRole)] async
             (long id, 
             CancellationToken cancellationToken, 
             ISender mediator, 

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalServiceEndPoints.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalServiceEndPoints.cs
@@ -144,7 +144,7 @@ public class MinimalServiceEndPoints
         }).WithMetadata(new SwaggerOperationAttribute("Create a Service", "Create a Service") { Tags = new[] { "Services" } });
         
         app.MapDelete("api/services/{id}",
-            [Authorize(Roles = $"{RoleTypes.DfeAdmin},{RoleTypes.LaManager},{RoleTypes.LaDualRole}")] async 
+            [Authorize(Roles = $"{RoleTypes.DfeAdmin},{RoleTypes.LaManager},{RoleTypes.LaDualRole},{RoleTypes.VcsManager}")] async
             (long id, 
             CancellationToken cancellationToken, 
             ISender mediator, 

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -253,7 +253,7 @@
                          action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Service_More_Details, ServiceJourneyChangeFlow.SinglePage)">@service.MoreDetails.GetDisplay()</summary-row>
         </summary-list>
         
-        @if (Model.Flow == JourneyFlow.Edit && Model.FamilyHubsUser.Role is RoleTypes.LaManager or RoleTypes.LaDualRole)
+        @if (Model.Flow == JourneyFlow.Edit && Model.FamilyHubsUser.Role is RoleTypes.LaManager or RoleTypes.LaDualRole or RoleTypes.VcsManager)
         {
             <h2 class="govuk-heading-m">Delete this service</h2>
             <p class="govuk-!-margin-bottom-9">You can <a asp-page="/manage-services/delete-service" asp-route-serviceId="@Model.ServiceModel.Id">delete this service</a> if you want to permanently remove it from the directory.</p>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -253,7 +253,7 @@
                          action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Service_More_Details, ServiceJourneyChangeFlow.SinglePage)">@service.MoreDetails.GetDisplay()</summary-row>
         </summary-list>
         
-        @if (Model.Flow == JourneyFlow.Edit && Model.FamilyHubsUser.Role is RoleTypes.LaManager or RoleTypes.LaDualRole or RoleTypes.VcsManager)
+        @if (Model.Flow == JourneyFlow.Edit && Model.UserRoleCanDeleteService)
         {
             <h2 class="govuk-heading-m">Delete this service</h2>
             <p class="govuk-!-margin-bottom-9">You can <a asp-page="/manage-services/delete-service" asp-route-serviceId="@Model.ServiceModel.Id">delete this service</a> if you want to permanently remove it from the directory.</p>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
@@ -16,6 +16,8 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 [Authorize(Roles = RoleGroups.AdminRole)]
 public class Service_DetailModel : ServicePageModel
 {
+    private const string DeleteServiceRoles = $"{RoleGroups.LaManagerOrDualRole},{RoleGroups.VcsManagerOrDualRole}";
+
     public static IReadOnlyDictionary<long, string>? TaxonomyIdToName { get; set; } 
 
     public string? OrganisationName { get; private set; }
@@ -24,7 +26,7 @@ public class Service_DetailModel : ServicePageModel
     private readonly IServiceDirectoryClient _serviceDirectoryClient;
     private readonly ITaxonomyService _taxonomyService;
 
-    public bool UserRoleCanDeleteService => $"{RoleGroups.LaManagerOrDualRole},{RoleGroups.VcsManagerOrDualRole}".Contains(FamilyHubsUser.Role);
+    public bool UserRoleCanDeleteService => DeleteServiceRoles.Contains(FamilyHubsUser.Role);
 
     public Service_DetailModel(
         IRequestDistributedCache connectionRequestCache,

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
@@ -24,6 +24,8 @@ public class Service_DetailModel : ServicePageModel
     private readonly IServiceDirectoryClient _serviceDirectoryClient;
     private readonly ITaxonomyService _taxonomyService;
 
+    public bool UserRoleCanDeleteService => $"{RoleGroups.LaManagerOrDualRole},{RoleGroups.VcsManagerOrDualRole}".Contains(FamilyHubsUser.Role);
+
     public Service_DetailModel(
         IRequestDistributedCache connectionRequestCache,
         IServiceDirectoryClient serviceDirectoryClient,

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml
@@ -1,4 +1,5 @@
 @page
+@using FamilyHubs.SharedKernel.Identity
 @using FamilyHubs.SharedKernel.Razor.ErrorNext
 @model DeleteService
 @{
@@ -22,6 +23,16 @@
                 </h1>
             </legend>
             <p class="govuk-body">By deleting this service you will completely remove it from both the directory and Manage family support services and accounts.</p>
+            @if (Model.UserRole is RoleTypes.VcsManager)
+            {
+                <div class="govuk-warning-text">
+                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <strong class="govuk-warning-text__text">
+                        <span class="govuk-visually-hidden">Warning</span>
+                        You cannot delete a service if it has connection requests that have not been actioned.
+                    </strong>
+                </div>
+            }
             <form method="post" novalidate>
                 <div class="govuk-form-group @error?.FormGroupClass">
                     <h2 class="govuk-heading-m govuk-!-margin-top-6">Do you want to delete @Model.ServiceName?</h2>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml
@@ -23,7 +23,7 @@
                 </h1>
             </legend>
             <p class="govuk-body">By deleting this service you will completely remove it from both the directory and Manage family support services and accounts.</p>
-            @if (Model.UserRole is RoleTypes.VcsManager)
+            @if (Model.UserRoleCanSeeConnectionRequestWarning)
             {
                 <div class="govuk-warning-text">
                     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
@@ -19,7 +19,8 @@ public class DeleteService : PageModel
     public string BackUrl => "/manage-services/Service-Detail?flow=edit";
     [BindProperty] public long ServiceId { get; set; }
     public string ServiceName { get; set; } = null!;
-    public string UserRole => HttpContext.GetFamilyHubsUser().Role;
+    public bool UserRoleCanSeeConnectionRequestWarning =>
+        RoleGroups.VcsManagerOrDualRole.Contains(HttpContext.GetFamilyHubsUser().Role);
 
     [BindProperty] public bool? Selected { get; set; }
 

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using FamilyHubs.ServiceDirectory.Admin.Core.ApiClient;
 using FamilyHubs.ServiceDirectory.Admin.Core.Models;
+using FamilyHubs.SharedKernel.Identity;
 using FamilyHubs.SharedKernel.Razor.ErrorNext;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -18,6 +19,7 @@ public class DeleteService : PageModel
     public string BackUrl => "/manage-services/Service-Detail?flow=edit";
     [BindProperty] public long ServiceId { get; set; }
     public string ServiceName { get; set; } = null!;
+    public string UserRole => HttpContext.GetFamilyHubsUser().Role;
 
     [BindProperty] public bool? Selected { get; set; }
 


### PR DESCRIPTION
Ticket: [FHB-669](https://dfedigital.atlassian.net/browse/FHB-669)
Ticket: [FHB-670](https://dfedigital.atlassian.net/browse/FHB-670)

---

This PR enables functionality for VCS Manager + VCS Dual Role to delete services. It also makes sure that only VCS users can see the warning on the delete service page.

Note: `RoleGroups.AdminRole` == `"DfEAdmin,LaManager,LaDualUser,VcsManager,VcsDualRole"`

[FHB-669]: https://dfedigital.atlassian.net/browse/FHB-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FHB-670]: https://dfedigital.atlassian.net/browse/FHB-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ