### PR TITLE
FHB-673 : Fix Open Con. Req. Redirect Error

### DIFF
--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-error.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-error.cshtml.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 
-[Authorize(Roles = RoleGroups.LaManagerOrDualRole)]
 public class DeleteServiceErrorModel : PageModel
 {
     private readonly IServiceDirectoryClient _serviceDirectoryClient;

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-error.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-error.cshtml.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 
+[Authorize(Roles = RoleGroups.AdminRole)]
 public class DeleteServiceErrorModel : PageModel
 {
     private readonly IServiceDirectoryClient _serviceDirectoryClient;

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-shutter.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-shutter.cshtml.cs
@@ -1,9 +1,11 @@
-using FamilyHubs.ServiceDirectory.Admin.Web.Pages.Shared;
+using FamilyHubs.SharedKernel.Identity;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 
+[Authorize(Roles = RoleGroups.AdminRole)]
 public class DeleteServiceShutter : PageModel
 {
     public string ServiceName { get; set; } = null!;

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml
@@ -1,5 +1,4 @@
 @page
-@using FamilyHubs.SharedKernel.Identity
 @using FamilyHubs.SharedKernel.Razor.ErrorNext
 @model DeleteService
 @{

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
@@ -3,11 +3,13 @@ using FamilyHubs.ServiceDirectory.Admin.Core.ApiClient;
 using FamilyHubs.ServiceDirectory.Admin.Core.Models;
 using FamilyHubs.SharedKernel.Identity;
 using FamilyHubs.SharedKernel.Razor.ErrorNext;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 
+[Authorize(Roles = RoleGroups.AdminRole)]
 public class DeleteService : PageModel
 {
     private readonly IServiceDirectoryClient _serviceDirectoryClient;


### PR DESCRIPTION
Ticket: [FHB-673](https://dfedigital.atlassian.net/browse/FHB-673)

---

When a VCS user tries to delete a service that has open connection requests, they get an error redirect because the error page for this scenario is gated with authorisation for LA users.

This ticket updates the role to be the correct one, and on top of this gates the other pages on the delete journey to keep a consistent pattern.

[FHB-673]: https://dfedigital.atlassian.net/browse/FHB-673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ