### PR TITLE
FHB-785: Remove NuGet references to FamilyHubs.Notification.*

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -42,8 +42,6 @@
     <PackageVersion Include="EncryptColumn.Core" Version="1.0.0" />
     <PackageVersion Include="EntityFramework" Version="6.5.1" />
     <PackageVersion Include="Enums.NET" Version="5.0.0" />
-    <PackageVersion Include="FamilyHubs.Notification.Api.Client" Version="1.1.1" />
-    <PackageVersion Include="FamilyHubs.Notification.Api.Contracts" Version="1.0.3" />
     <PackageVersion Include="FamilyHubs.SharedKernel.Razor" Version="9.3.4" />
     <PackageVersion Include="Fare" Version="2.2.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />


### PR DESCRIPTION
References to the NuGet packages for FamilyHubs.Notification.* packages still exist in src/Directory.Packages.props even though we’ve moved to using project references.