### PR TITLE
FHB-675 : DfE Admin can delete LA & VCFS Services

### DIFF
--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
@@ -16,8 +16,6 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 [Authorize(Roles = RoleGroups.AdminRole)]
 public class Service_DetailModel : ServicePageModel
 {
-    private const string DeleteServiceRoles = $"{RoleGroups.LaManagerOrDualRole},{RoleGroups.VcsManagerOrDualRole}";
-
     public static IReadOnlyDictionary<long, string>? TaxonomyIdToName { get; set; } 
 
     public string? OrganisationName { get; private set; }
@@ -26,7 +24,7 @@ public class Service_DetailModel : ServicePageModel
     private readonly IServiceDirectoryClient _serviceDirectoryClient;
     private readonly ITaxonomyService _taxonomyService;
 
-    public bool UserRoleCanDeleteService => DeleteServiceRoles.Contains(FamilyHubsUser.Role);
+    public bool UserRoleCanDeleteService => RoleGroups.AdminRole.Contains(FamilyHubsUser.Role);
 
     public Service_DetailModel(
         IRequestDistributedCache connectionRequestCache,

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml
@@ -1,4 +1,5 @@
 @page
+@using FamilyHubs.ServiceDirectory.Shared.Enums
 @using FamilyHubs.SharedKernel.Razor.ErrorNext
 @model DeleteService
 @{
@@ -22,7 +23,7 @@
                 </h1>
             </legend>
             <p class="govuk-body">By deleting this service you will completely remove it from both the directory and Manage family support services and accounts.</p>
-            @if (Model.UserRoleCanSeeConnectionRequestWarning)
+            @if (Model.ServiceType == ServiceType.InformationSharing)
             {
                 <div class="govuk-warning-text">
                     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
 using FamilyHubs.ServiceDirectory.Admin.Core.ApiClient;
 using FamilyHubs.ServiceDirectory.Admin.Core.Models;
+using FamilyHubs.ServiceDirectory.Shared.Dto;
+using FamilyHubs.ServiceDirectory.Shared.Enums;
 using FamilyHubs.SharedKernel.Identity;
 using FamilyHubs.SharedKernel.Razor.ErrorNext;
 using Microsoft.AspNetCore.Authorization;
@@ -21,8 +23,7 @@ public class DeleteService : PageModel
     public string BackUrl => "/manage-services/Service-Detail?flow=edit";
     [BindProperty] public long ServiceId { get; set; }
     public string ServiceName { get; set; } = null!;
-    public bool UserRoleCanSeeConnectionRequestWarning =>
-        RoleGroups.VcsManagerOrDualRole.Contains(HttpContext.GetFamilyHubsUser().Role);
+    public ServiceType ServiceType { get; set; }
 
     [BindProperty] public bool? Selected { get; set; }
 
@@ -37,8 +38,13 @@ public class DeleteService : PageModel
     private async Task<bool> IsOpenConnectionRequests() =>
         await _referralServiceClient.GetReferralsCountByServiceId(ServiceId) > 0;
 
-    private async Task<string> GetServiceName() =>
-        (await _serviceDirectoryClient.GetServiceById(ServiceId)).Name;
+    private async Task SetServiceInformation()
+    {
+        ServiceDto serviceDto = await _serviceDirectoryClient.GetServiceById(ServiceId);
+
+        ServiceName = serviceDto.Name;
+        ServiceType = serviceDto.ServiceType;
+    }
 
     private async Task MarkServiceAsDefunct() => await _serviceDirectoryClient.DeleteService(ServiceId);
 
@@ -53,7 +59,7 @@ public class DeleteService : PageModel
 
     public async Task<IActionResult> OnPostAsync()
     {
-        ServiceName = await GetServiceName();
+        await SetServiceInformation();
 
         if (NeitherRadioButtonIsSelected())
         {
@@ -79,7 +85,8 @@ public class DeleteService : PageModel
     public async Task<IActionResult> OnGetAsync(long serviceId)
     {
         ServiceId = serviceId;
-        ServiceName = await GetServiceName();
+
+        await SetServiceInformation();
 
         return Page();
     }

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service.cshtml.cs
@@ -36,7 +36,7 @@ public class DeleteService : PageModel
     }
 
     private async Task<bool> IsOpenConnectionRequests() =>
-        await _referralServiceClient.GetReferralsCountByServiceId(ServiceId) > 0;
+        ServiceType == ServiceType.InformationSharing && await _referralServiceClient.GetReferralsCountByServiceId(ServiceId) > 0;
 
     private async Task SetServiceInformation()
     {


### PR DESCRIPTION
Ticket: [FHB-675](https://dfedigital.atlassian.net/browse/FHB-675)

---

This PR:

- Enables DfE Admin users to see the delete link, which allows them to delete a service

- Refactors the delete page to show the open connection request warning dependent on Service Type instead of Role, as `FamilySharing` are services that only show up on Find, and are also only LA services (which can't have connection requests), whilst `InformationSharing` are services that only show up on Connect, and are also only VCFS services (which can have connection requests).

- Saves some performance by only checking for open connection requests if the service type is `InformationSharing` (aka a VCFS service), since as mentioned above LA services can't ever have connection requests against them.

[FHB-675]: https://dfedigital.atlassian.net/browse/FHB-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ