### PR TITLE
FHB-842:  login bug

### DIFF
--- a/src/SuperSolution.sln
+++ b/src/SuperSolution.sln
@@ -257,6 +257,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4D2300AF-512
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FamilyHubs.Mock-Hsda.Api", "service\mock-hsda-api\src\FamilyHubs.Mock-Hsda.Api\FamilyHubs.Mock-Hsda.Api.csproj", "{3410936A-B361-40F5-AD43-ED4100E24059}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FamilyHubs.Idam.Api.UnitTests", "service\idam-api\tests\FamilyHubs.Idam.Api.UnitTests\FamilyHubs.Idam.Api.UnitTests.csproj", "{E16B478A-82FA-43C1-9135-E7411EC14013}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -546,6 +548,10 @@ Global
 		{3410936A-B361-40F5-AD43-ED4100E24059}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3410936A-B361-40F5-AD43-ED4100E24059}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3410936A-B361-40F5-AD43-ED4100E24059}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E16B478A-82FA-43C1-9135-E7411EC14013}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E16B478A-82FA-43C1-9135-E7411EC14013}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E16B478A-82FA-43C1-9135-E7411EC14013}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E16B478A-82FA-43C1-9135-E7411EC14013}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{3BDE7741-0874-4DCE-BC06-A6996C24F150} = {FA55DA32-3617-4409-9F03-73BDD536DDF4}
@@ -671,5 +677,6 @@ Global
 		{AB3F357F-D9BD-430C-97C9-70185D247EB6} = {9F3BAA04-4BF5-4CEF-A586-0221D8C7FE44}
 		{4D2300AF-512A-4D1B-BA1D-D2A8DD862097} = {AB3F357F-D9BD-430C-97C9-70185D247EB6}
 		{3410936A-B361-40F5-AD43-ED4100E24059} = {4D2300AF-512A-4D1B-BA1D-D2A8DD862097}
+		{E16B478A-82FA-43C1-9135-E7411EC14013} = {253E18DD-B081-4FAB-86C3-674F34A9BF9F}
 	EndGlobalSection
 EndGlobal

--- a/src/service/idam-api/src/FamilyHubs.Idam.Api/Controllers/UserSessionController.cs
+++ b/src/service/idam-api/src/FamilyHubs.Idam.Api/Controllers/UserSessionController.cs
@@ -16,8 +16,9 @@ public class UserSessionController(IMediator mediator) : ControllerBase
     [HttpPost]
     public async Task<string> Create([FromBody] AddUserSessionCommand request, CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(request, cancellationToken);
         _ = await mediator.Send(new DeleteExpiredUserSessionsCommand(), cancellationToken).ConfigureAwait(false);
+        var result = await mediator.Send(request, cancellationToken);
+        
         HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
         HttpContext.Response.Headers.Append("Location", $"Api/UserSession/{result}");
         return result;

--- a/src/service/idam-api/src/FamilyHubs.Idam.Core/Commands/Delete/DeleteExpiredUserSessionsCommand.cs
+++ b/src/service/idam-api/src/FamilyHubs.Idam.Core/Commands/Delete/DeleteExpiredUserSessionsCommand.cs
@@ -1,5 +1,4 @@
 ﻿using FamilyHubs.Idam.Core.Exceptions;
-using FamilyHubs.Idam.Data.Entities;
 using FamilyHubs.Idam.Data.Repository;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -8,9 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace FamilyHubs.Idam.Core.Commands.Delete;
 
-public class DeleteExpiredUserSessionsCommand : IRequest<bool>
-{
-}
+public class DeleteExpiredUserSessionsCommand : IRequest<bool>;
 
 public class DeleteExpiredUserSessionsCommandHandler : IRequestHandler<DeleteExpiredUserSessionsCommand, bool>
 {
@@ -31,19 +28,19 @@ public class DeleteExpiredUserSessionsCommandHandler : IRequestHandler<DeleteExp
         {
             _logger.LogInformation("DeleteExpiredUserSessionsCommand started");
 
-            int? cleanupInterval = _configuration.GetValue<int?>("ExpiredSessionCleanupInterval");
+            var cleanupInterval = _configuration.GetValue<int?>("ExpiredSessionCleanupInterval");
             if (cleanupInterval is null)
             {
                 _logger.LogError("ExpiredSessionCleanupInterval not configured.");
                 throw new IdamsException("ExpiredSessionCleanupInterval not configured.");
             }
-            DateTime sessionExpiryTime = DateTime.UtcNow.AddSeconds((int)-cleanupInterval);
-            List<UserSession> entities =
+            var sessionExpiryTime = DateTime.UtcNow.AddSeconds((int)-cleanupInterval);
+            var entities =
                 await _dbContext.UserSessions.Where(r => r.LastActive < sessionExpiryTime).ToListAsync(cancellationToken);
 
             _logger.LogInformation("Found: {CountExpired} expired sessions.", entities.Count);
 
-            if (entities.Any())
+            if (entities.Count != 0)
             {
                 _dbContext.UserSessions.RemoveRange(entities);
 

--- a/src/service/idam-api/src/FamilyHubs.Idam.Core/Commands/Delete/DeleteExpiredUserSessionsCommand.cs
+++ b/src/service/idam-api/src/FamilyHubs.Idam.Core/Commands/Delete/DeleteExpiredUserSessionsCommand.cs
@@ -40,7 +40,7 @@ public class DeleteExpiredUserSessionsCommandHandler : IRequestHandler<DeleteExp
 
             _logger.LogInformation("Found: {CountExpired} expired sessions.", entities.Count);
 
-            if (entities.Count != 0)
+            if (entities.Count > 0)
             {
                 _dbContext.UserSessions.RemoveRange(entities);
 

--- a/src/service/idam-api/tests/FamilyHubs.Idam.Api.UnitTests/ControllerTests/WhenPostCreateUserSession.cs
+++ b/src/service/idam-api/tests/FamilyHubs.Idam.Api.UnitTests/ControllerTests/WhenPostCreateUserSession.cs
@@ -1,0 +1,69 @@
+using FamilyHubs.Idam.Api.Controllers;
+using FamilyHubs.Idam.Core.Commands.Add;
+using FamilyHubs.Idam.Core.Commands.Delete;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+
+namespace FamilyHubs.Idam.Api.UnitTests.ControllerTests;
+
+public class WhenPostCreateUserSession
+{
+    private readonly UserSessionController _sut;
+    private readonly IMediator _mediator;
+
+    public WhenPostCreateUserSession()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _sut = new UserSessionController(_mediator)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    [Fact]
+    public async Task ShouldCallDeleteExpiredFirstBeforeTryingToAddSession()
+    {
+        // Arrange
+        var addUserSessionCommand = new AddUserSessionCommand
+        {
+            Sid = "aSid",
+            Email = "ASidEmail@sid.com"
+        };
+        _mediator.Send(addUserSessionCommand, CancellationToken.None)
+            .Returns("sid");
+
+        // Act
+        await _sut.Create(addUserSessionCommand, CancellationToken.None);
+
+        // Assert
+        Received.InOrder(() =>
+        {
+            _mediator.Send(Arg.Any<DeleteExpiredUserSessionsCommand>(), CancellationToken.None);
+            _mediator.Send(addUserSessionCommand, CancellationToken.None);
+        });
+    }
+    
+    [Fact]
+    public async Task ShouldReturnSidWhenSessionIsCreated()
+    {
+        // Arrange
+        var addUserSessionCommand = new AddUserSessionCommand
+        {
+            Sid = "aSid",
+            Email = "ASidEmail@sid.com"
+        };
+        _mediator.Send(addUserSessionCommand, CancellationToken.None)
+            .Returns("sid");
+
+        // Act
+        var result = await _sut.Create(addUserSessionCommand, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("sid", result);
+    }
+}

--- a/src/service/idam-api/tests/FamilyHubs.Idam.Api.UnitTests/FamilyHubs.Idam.Api.UnitTests.csproj
+++ b/src/service/idam-api/tests/FamilyHubs.Idam.Api.UnitTests/FamilyHubs.Idam.Api.UnitTests.csproj
@@ -10,11 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="NSubstitute" />
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/service/idam-api/tests/FamilyHubs.Idam.Api.UnitTests/FamilyHubs.Idam.Api.UnitTests.csproj
+++ b/src/service/idam-api/tests/FamilyHubs.Idam.Api.UnitTests/FamilyHubs.Idam.Api.UnitTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\FamilyHubs.Idam.Api\FamilyHubs.Idam.Api.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Difficult to diagnose issue as the sessions are deleted as soon as someone else successfully logs in.
The theory is that the service was able to post a new session with the same SID as one that already existed. As the error only seems to occur in the morning, it's possible that it's old expired sessions.
This update is to ensure expired ones are removed first before attempting a new one.

Monitoring app insights after this goes in can tell us if it's working or not.