### PR TITLE
FHB-671 : DfE Admin & VCFS Admin Error Page

### DIFF
--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/_DeleteServiceErrorDfEAdmin.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/_DeleteServiceErrorDfEAdmin.cshtml
@@ -1,0 +1,5 @@
+@model FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services.DeleteServiceErrorModel
+
+<p>This is because there are outstanding connection requests on Connect families to support.</p>
+
+<p>@Model.VcfsOrganisationName will need to accept or reject these requests. You can find someone who can manage requests by <a href="/AccountAdmin/ManagePermissions">checking the list of users</a>.</p>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/_DeleteServiceErrorVcfsAdmin.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/_DeleteServiceErrorVcfsAdmin.cshtml
@@ -1,0 +1,6 @@
+@using FamilyHubs.SharedKernel.Razor.Urls
+@model FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services.DeleteServiceErrorModel
+
+<p>This is because there are outstanding connection requests.</p>
+
+<p>Someone from your organisation will need to accept or reject these requests. Anyone with access can do this by going to the <a href="@Html.FamilyHubUrl(UrlKeys.DashboardWeb, "/La/Dashboard")" new-tab>‘My requests’ page on Connect families to support</a>.</p>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-error.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-error.cshtml
@@ -1,5 +1,4 @@
 @page
-@using FamilyHubs.SharedKernel.Razor.Urls
 @model FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services.DeleteServiceErrorModel
 
 @{
@@ -8,16 +7,10 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">@ViewData["Title"]</h1>
+        <h1 class="govuk-heading-l">You cannot delete @Model.ServiceName yet</h1>
 
-        <p>@Model.ServiceName cannot be deleted because there are outstanding connection requests.</p>
-
-        <ul>
-            <li>manage these request yourself, if you have access, by <a href="@Html.FamilyHubUrl(UrlKeys.DashboardWeb, "/La/Dashboard")" new-tab>going to the ‘My requests’ page on Connect</a></li>
-            <li>find someone who can make and manage requests on Connect, by <a href="/AccountAdmin/ManagePermissions">checking your organisation’s list of users</a></li>
-        </ul>
+        @await Html.PartialAsync(Model.IsUserDfEAdmin ? "_DeleteServiceErrorDfEAdmin" : "_DeleteServiceErrorVcfsAdmin", Model)
 
         <a class="govuk-button" asp-page="/Welcome">Go to homepage</a>
     </div>
-
 </div>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-shutter.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/delete-service-shutter.cshtml
@@ -5,11 +5,9 @@
     ViewData["Title"] = "Deleting a Service";
 }
 
-<form method="post">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">You have @Model.Qualifier deleted @Model.ServiceName</h1>
-            <a class="govuk-button" href="/Welcome">Go to homepage</a>
-        </div>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">You have @Model.Qualifier deleted @Model.ServiceName</h1>
+        <a class="govuk-button" href="/Welcome">Go to homepage</a>
     </div>
-</form>
+</div>


### PR DESCRIPTION
Ticket: [FHB-671](https://dfedigital.atlassian.net/browse/FHB-671)

---

This PR:

- Shows two different error pages when deleting a service with open connection requests. One for DfE Admin and one for VCFS Admins (i.e., VCFS Manager or VCFS Dual Role)

- Removes a redundant `<form>` tag on the shutter page as a bit of cleanup