### PR TITLE
FHB-805 : Display Services & Family Hub Locations

### DIFF
--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalLocationEndPoints.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalLocationEndPoints.cs
@@ -17,11 +17,20 @@ public class MinimalLocationEndPoints
 {
     public void RegisterLocationEndPoints(WebApplication app)
     {
-        app.MapGet("api/locations", async (int? pageNumber, string? orderByColumn, int? pageSize, bool? isAscending, string? searchName, bool? isFamilyHub, CancellationToken cancellationToken, ISender mediator, ILogger<MinimalLocationEndPoints> logger) =>
+        app.MapGet("api/locations", async(
+            int? pageNumber,
+            string? orderByColumn,
+            int? pageSize,
+            bool? isAscending,
+            string? searchName,
+            bool? isFamilyHub,
+            double? latitude,
+            double? longitude,
+            CancellationToken cancellationToken, ISender mediator, ILogger<MinimalLocationEndPoints> logger) =>
         {
             try
             {
-                var command = new ListLocationsCommand(pageNumber, orderByColumn, pageSize, isAscending, searchName, isFamilyHub);
+                var command = new ListLocationsCommand(pageNumber, orderByColumn, pageSize, isAscending, searchName, isFamilyHub, latitude, longitude);
                 var result = await mediator.Send(command, cancellationToken);
                 return result;
             }

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Core/Queries/Locations/ListLocations/ListLocationsCommand.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Core/Queries/Locations/ListLocations/ListLocationsCommand.cs
@@ -1,12 +1,14 @@
 ﻿using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using FamilyHubs.ServiceDirectory.Core.Helper;
-using FamilyHubs.ServiceDirectory.Data.Entities;
 using FamilyHubs.ServiceDirectory.Data.Repository;
 using FamilyHubs.ServiceDirectory.Shared.Dto;
 using FamilyHubs.ServiceDirectory.Shared.Models;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using NetTopologySuite;
+using NetTopologySuite.Geometries;
+using Location = FamilyHubs.ServiceDirectory.Data.Entities.Location;
 
 namespace FamilyHubs.ServiceDirectory.Core.Queries.Locations.ListLocations;
 
@@ -17,9 +19,11 @@ public class ListLocationsCommand : IRequest<PaginatedList<LocationDto>>
     public bool IsAscending { get; }
     public string? SearchName { get; }
     public bool IsFamilyHub { get; }
+    public double? Latitude { get; }
+    public double? Longitude { get; }
     public string OrderByColumn { get; }
 
-    public ListLocationsCommand(int? pageNumber, string? orderByColumn, int? pageSize, bool? isAscending, string? searchName, bool? isFamilyHub)
+    public ListLocationsCommand(int? pageNumber, string? orderByColumn, int? pageSize, bool? isAscending, string? searchName, bool? isFamilyHub, double? latitude, double? longitude)
     {
         PageNumber = pageNumber ?? 1;
         OrderByColumn = orderByColumn ?? "Location";
@@ -27,6 +31,8 @@ public class ListLocationsCommand : IRequest<PaginatedList<LocationDto>>
         IsAscending = isAscending ?? true;
         SearchName = searchName;
         IsFamilyHub = isFamilyHub ?? false;
+        Latitude = latitude;
+        Longitude = longitude;
     }
 }
 
@@ -34,6 +40,9 @@ public class ListLocationCommandHandler : IRequestHandler<ListLocationsCommand, 
 {
     private readonly ApplicationDbContext _context;
     private readonly IMapper _mapper;
+
+    private static readonly GeometryFactory GeometryFactory =
+        NtsGeometryServices.Instance.CreateGeometryFactory(srid: GeoPoint.WGS84);
 
     public ListLocationCommandHandler(ApplicationDbContext context, IMapper mapper)
     {
@@ -49,6 +58,7 @@ public class ListLocationCommandHandler : IRequestHandler<ListLocationsCommand, 
 
         locationsQuery = Search(request, locationsQuery);
         locationsQuery = OrderBy(request, locationsQuery);
+        locationsQuery = FilterByDistance(request, locationsQuery);
 
         var locations = await locationsQuery
             .Skip(skip)
@@ -71,7 +81,7 @@ public class ListLocationCommandHandler : IRequestHandler<ListLocationsCommand, 
         return count;
     }
 
-    private IQueryable<Location> Search(ListLocationsCommand request, IQueryable<Location> locationsQuery)
+    private static IQueryable<Location> Search(ListLocationsCommand request, IQueryable<Location> locationsQuery)
     {
         if (!string.IsNullOrEmpty(request.SearchName))
         {
@@ -98,7 +108,7 @@ public class ListLocationCommandHandler : IRequestHandler<ListLocationsCommand, 
         return locationsQuery;
     }
 
-    private IQueryable<Location> OrderBy(ListLocationsCommand request, IQueryable<Location> locationsQuery)
+    private static IQueryable<Location> OrderBy(ListLocationsCommand request, IQueryable<Location> locationsQuery)
     {
         switch (request.OrderByColumn)
         {
@@ -113,5 +123,15 @@ public class ListLocationCommandHandler : IRequestHandler<ListLocationsCommand, 
         }
 
         return locationsQuery;
+    }
+
+    private static IQueryable<Location> FilterByDistance(ListLocationsCommand request,
+        IQueryable<Location> locationsQuery)
+    {
+        if (request.Latitude is null || request.Longitude is null) return locationsQuery;
+
+        Point userLocation = GeometryFactory.CreatePoint(new Coordinate(request.Longitude.Value, request.Latitude.Value));
+
+        return locationsQuery.OrderBy(location => location.GeoPoint.Distance(userLocation));
     }
 }

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Core/Queries/Locations/ListLocations/ListLocationsCommand.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Core/Queries/Locations/ListLocations/ListLocationsCommand.cs
@@ -67,6 +67,8 @@ public class ListLocationCommandHandler : IRequestHandler<ListLocationsCommand, 
             .AsNoTracking()
             .ToListAsync(cancellationToken);
 
+        locations.ForEach(location => location.Distance = GetDistanceInMeters(request.Latitude, request.Longitude, location.Latitude, location.Longitude));
+
         int totalCount = await GetTotalCount(request, cancellationToken);
 
         return new PaginatedList<LocationDto>(locations, totalCount, request.PageNumber, request.PageSize);
@@ -134,4 +136,7 @@ public class ListLocationCommandHandler : IRequestHandler<ListLocationsCommand, 
 
         return locationsQuery.OrderBy(location => location.GeoPoint.Distance(userLocation));
     }
+
+    private static double GetDistanceInMeters(double? fromLatitude, double? fromLongitude, double? toLatitude,
+        double? toLongitude) => HelperUtility.GetDistance(fromLatitude, fromLongitude, toLatitude, toLongitude);
 }

--- a/src/service/service-directory-api/tests/FamilyHubs.ServiceDirectory.Core.IntegrationTests/Locations/WhenUsingGetLocationCommands.cs
+++ b/src/service/service-directory-api/tests/FamilyHubs.ServiceDirectory.Core.IntegrationTests/Locations/WhenUsingGetLocationCommands.cs
@@ -75,7 +75,7 @@ public class WhenUsingGetLocationCommands : DataIntegrationTestBase
         //Arrange
         var services = await CreateManyTestServicesQueryTesting();
 
-        var getCommand = new ListLocationsCommand(null, null, null, null,null, null);
+        var getCommand = new ListLocationsCommand(null, null, null, null,null, null, null, null);
         var getHandler = new ListLocationCommandHandler(TestDbContext, Mapper);
 
         //Act

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Core/ServiceDirectory/Interfaces/IServiceDirectoryClient.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Core/ServiceDirectory/Interfaces/IServiceDirectoryClient.cs
@@ -36,4 +36,6 @@ public interface IServiceDirectoryClient
         HttpStatusCode? responseStatusCode,
         Guid correlationId
     );
+
+    Task<PaginatedList<LocationDto>> GetLocations(bool isFamilyHub, CancellationToken cancellationToken = default);
 }

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Core/ServiceDirectory/Interfaces/IServiceDirectoryClient.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Core/ServiceDirectory/Interfaces/IServiceDirectoryClient.cs
@@ -37,5 +37,5 @@ public interface IServiceDirectoryClient
         Guid correlationId
     );
 
-    Task<PaginatedList<LocationDto>> GetLocations(bool isFamilyHub, CancellationToken cancellationToken = default);
+    Task<PaginatedList<LocationDto>> GetLocations(bool isFamilyHub, double? latitude, double? longitude, CancellationToken cancellationToken = default);
 }

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Core/ServiceDirectory/Interfaces/IServiceDirectoryClient.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Core/ServiceDirectory/Interfaces/IServiceDirectoryClient.cs
@@ -37,5 +37,5 @@ public interface IServiceDirectoryClient
         Guid correlationId
     );
 
-    Task<PaginatedList<LocationDto>> GetLocations(bool isFamilyHub, double? latitude, double? longitude, CancellationToken cancellationToken = default);
+    Task<PaginatedList<LocationDto>> GetLocations(bool isFamilyHub, int? pageNumber, int? pageSize, double? latitude, double? longitude, CancellationToken cancellationToken = default);
 }

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Infrastructure/Services/ServiceDirectory/ServiceDirectoryClient.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Infrastructure/Services/ServiceDirectory/ServiceDirectoryClient.cs
@@ -11,6 +11,7 @@ using FamilyHubs.SharedKernel.HealthCheck;
 using FamilyHubs.ServiceDirectory.Shared.Dto.Metrics;
 using FamilyHubs.ServiceDirectory.Shared.Enums;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace FamilyHubs.ServiceDirectory.Infrastructure.Services.ServiceDirectory;
 
@@ -267,11 +268,24 @@ public class ServiceDirectoryClient : IServiceDirectoryClient, IHealthCheckUrlGr
 
     }
 
-    public async Task<PaginatedList<LocationDto>> GetLocations(bool isFamilyHub, CancellationToken cancellationToken = default)
+    public async Task<PaginatedList<LocationDto>> GetLocations(bool isFamilyHub, double? latitude, double? longitude, CancellationToken cancellationToken = default)
     {
         HttpClient httpClient = _httpClientFactory.CreateClient(HttpClientName);
 
-        HttpResponseMessage response = await httpClient.GetAsync($"api/locations?isFamilyHub={isFamilyHub}", cancellationToken);
+        Dictionary<string, string?> queryParameters = new()
+        {
+            { "isFamilyHub", $"{isFamilyHub}" }
+        };
+
+        if (latitude is not null && longitude is not null)
+        {
+            queryParameters.Add("latitude", $"{latitude}");
+            queryParameters.Add("longitude", $"{longitude}");
+        }
+
+        string locationUrl = new(QueryHelpers.AddQueryString("api/locations", queryParameters));
+
+        HttpResponseMessage response = await httpClient.GetAsync(locationUrl, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Infrastructure/Services/ServiceDirectory/ServiceDirectoryClient.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Infrastructure/Services/ServiceDirectory/ServiceDirectoryClient.cs
@@ -268,13 +268,15 @@ public class ServiceDirectoryClient : IServiceDirectoryClient, IHealthCheckUrlGr
 
     }
 
-    public async Task<PaginatedList<LocationDto>> GetLocations(bool isFamilyHub, double? latitude, double? longitude, CancellationToken cancellationToken = default)
+    public async Task<PaginatedList<LocationDto>> GetLocations(bool isFamilyHub, int? pageNumber, int? pageSize, double? latitude, double? longitude, CancellationToken cancellationToken = default)
     {
         HttpClient httpClient = _httpClientFactory.CreateClient(HttpClientName);
 
         Dictionary<string, string?> queryParameters = new()
         {
-            { "isFamilyHub", $"{isFamilyHub}" }
+            { "isFamilyHub", $"{isFamilyHub}" },
+            { "pageNumber", $"{pageNumber}" },
+            { "pageSize", $"{pageSize}" }
         };
 
         if (latitude is not null && longitude is not null)

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/LocationMapper.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/LocationMapper.cs
@@ -10,10 +10,8 @@ public static class LocationMapper
         return locations.Select(ToModel);
     }
 
-    public static Location ToModel(LocationDto locationDto)
+    private static Location ToModel(LocationDto locationDto)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(locationDto.Name);
-
         return new Location(
             Name: locationDto.Name,
             Address:

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/LocationMapper.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/LocationMapper.cs
@@ -1,3 +1,4 @@
+using FamilyHubs.ServiceDirectory.Core.Distance;
 using FamilyHubs.ServiceDirectory.Shared.Dto;
 using FamilyHubs.ServiceDirectory.Web.Models;
 
@@ -24,6 +25,6 @@ public static class LocationMapper
                 locationDto.Country
             ],
             MoreDetails: locationDto.Description,
-            Distance: locationDto.Distance);
+            Distance: locationDto.Distance is not null ? DistanceConverter.MetersToMiles(locationDto.Distance.Value) : null);
     }
 }

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/LocationMapper.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/LocationMapper.cs
@@ -1,0 +1,31 @@
+using FamilyHubs.ServiceDirectory.Shared.Dto;
+using FamilyHubs.ServiceDirectory.Web.Models;
+
+namespace FamilyHubs.ServiceDirectory.Web.Mappers;
+
+public static class LocationMapper
+{
+    public static IEnumerable<Location> ToModel(IEnumerable<LocationDto> locations)
+    {
+        return locations.Select(ToModel);
+    }
+
+    public static Location ToModel(LocationDto locationDto)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(locationDto.Name);
+
+        return new Location(
+            Name: locationDto.Name,
+            Address:
+            [
+                locationDto.Address1,
+                locationDto.Address2,
+                locationDto.City,
+                locationDto.PostCode,
+                locationDto.StateProvince,
+                locationDto.Country
+            ],
+            MoreDetails: locationDto.Description,
+            Distance: locationDto.Distance);
+    }
+}

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/ServiceMapper.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/ServiceMapper.cs
@@ -5,7 +5,6 @@ using FamilyHubs.ServiceDirectory.Shared.Display;
 using FamilyHubs.ServiceDirectory.Shared.Dto;
 using FamilyHubs.ServiceDirectory.Shared.Enums;
 using FamilyHubs.ServiceDirectory.Shared.Extensions;
-using ServiceType = FamilyHubs.ServiceDirectory.Web.Models.ServiceType;
 
 namespace FamilyHubs.ServiceDirectory.Web.Mappers;
 
@@ -19,7 +18,7 @@ public static class ServiceMapper
 
     private static Service ToViewModel(ServiceDto service)
     {
-        Debug.Assert(service.ServiceType == Shared.Enums.ServiceType.FamilyExperience);
+        Debug.Assert(service.ServiceType == ServiceType.FamilyExperience); // TODO: FHB-805 What is this doing here???
 
         var location = service.Locations.First();
         var eligibility = service.Eligibilities.FirstOrDefault();
@@ -28,7 +27,6 @@ public static class ServiceMapper
         var contact = service.GetContact();
 
         return new Service(
-            IsFamilyHub(location) ? ServiceType.FamilyHub : ServiceType.Service,
             name,
             service.Distance != null ? DistanceConverter.MetersToMiles(service.Distance.Value) : null,
             GetCost(service),
@@ -47,10 +45,10 @@ public static class ServiceMapper
         return eligibility == null ? null : $"{AgeToString(eligibility.MinimumAge)} to {AgeToString(eligibility.MaximumAge)}";
     }
 
-    private static bool IsFamilyHub(LocationDto location)
-    {
-        return location.LocationTypeCategory == LocationTypeCategory.FamilyHub;
-    }
+    // private static bool IsFamilyHub(LocationDto location) // TODO : FHB-805 Will be useful later... .... ..
+    // {
+    //     return location.LocationTypeCategory == LocationTypeCategory.FamilyHub;
+    // }
 
     private static string? GetWebsiteUrl(string? url)
     {

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/ServiceMapper.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Mappers/ServiceMapper.cs
@@ -11,12 +11,12 @@ namespace FamilyHubs.ServiceDirectory.Web.Mappers;
 //todo: use extension methods?
 public static class ServiceMapper
 {
-    public static IEnumerable<Service> ToViewModel(IEnumerable<ServiceDto> services)
+    public static IEnumerable<Service> ToModel(IEnumerable<ServiceDto> services)
     {
-        return services.Select(ToViewModel);
+        return services.Select(ToModel);
     }
 
-    private static Service ToViewModel(ServiceDto service)
+    private static Service ToModel(ServiceDto service)
     {
         Debug.Assert(service.ServiceType == ServiceType.FamilyExperience); // TODO: FHB-805 What is this doing here???
 
@@ -71,11 +71,11 @@ public static class ServiceMapper
     {
         const string free = "Free";
 
-        if (!service.CostOptions.Any())
+        if (service.CostOptions.Count == 0)
         {
-            return new[] { free };
+            return [free];
         }
-        return new[] { "Yes, it costs money to use. " + service.CostOptions.First().AmountDescription };
+        return ["Yes, it costs money to use. " + service.CostOptions.First().AmountDescription];
     }
 
     private static string AgeToString(int age)

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/Location.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/Location.cs
@@ -1,0 +1,4 @@
+namespace FamilyHubs.ServiceDirectory.Web.Models;
+
+public record Location(string Name, IEnumerable<string?> Address, string? MoreDetails, double? Distance)
+    : ServiceDetail(Distance, ServiceDetailType.Location);

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/Location.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/Location.cs
@@ -1,4 +1,4 @@
 namespace FamilyHubs.ServiceDirectory.Web.Models;
 
-public record Location(string Name, IEnumerable<string?> Address, string? MoreDetails, double? Distance)
+public record Location(string? Name, IEnumerable<string?> Address, string? MoreDetails, double? Distance)
     : ServiceDetail(Distance, ServiceDetailType.Location);

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/Service.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/Service.cs
@@ -1,16 +1,9 @@
 ﻿
 namespace FamilyHubs.ServiceDirectory.Web.Models
 {
-    public enum ServiceType
-    {
-        FamilyHub,
-        Service
-    }
-
     //todo: type hierarchy, rather than type? or just null what we don't have?
     // when / opening hours will show regular schedule only. holiday schedule will be ignored for mvp (probably just show the description field)
     public sealed record Service(
-        ServiceType Type,
         string Name,
         //todo: what's actually mandatory?
         double? Distance,

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/Service.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/Service.cs
@@ -1,19 +1,14 @@
-﻿
-namespace FamilyHubs.ServiceDirectory.Web.Models
-{
-    //todo: type hierarchy, rather than type? or just null what we don't have?
-    // when / opening hours will show regular schedule only. holiday schedule will be ignored for mvp (probably just show the description field)
-    public sealed record Service(
-        string Name,
-        //todo: what's actually mandatory?
-        double? Distance,
-        IEnumerable<string> Cost,
-        IEnumerable<string> Where,
-        IEnumerable<string> When,
-        IEnumerable<string> Categories,
-        string? AgeRange = null,
-        string? Phone = null,
-        string? Email = null,
-        string? WebsiteName = null,
-        string? WebsiteUrl = null);
-}
+﻿namespace FamilyHubs.ServiceDirectory.Web.Models;
+
+public record Service(
+    string Name,
+    double? Distance,
+    IEnumerable<string> Cost,
+    IEnumerable<string> Where,
+    IEnumerable<string> When,
+    IEnumerable<string> Categories,
+    string? AgeRange = null,
+    string? Phone = null,
+    string? Email = null,
+    string? WebsiteName = null,
+    string? WebsiteUrl = null) : ServiceDetail(Distance, ServiceDetailType.Service);

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/ServiceDetail.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Models/ServiceDetail.cs
@@ -1,0 +1,9 @@
+namespace FamilyHubs.ServiceDirectory.Web.Models;
+
+public enum ServiceDetailType
+{
+    Service,
+    Location
+}
+
+public abstract record ServiceDetail(double? Distance, ServiceDetailType ServiceDetailType);

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml
@@ -16,7 +16,7 @@
 }
 
 @*todo: doesn't let user unselect default 'within 20 miles'!*@
-@if (Model.FromPostcodeSearch && !Model.Services.Any()) {
+@if (Model.FromPostcodeSearch && !Model.ServiceDetailList.Any()) {
     <partial name="_ServiceFilterNoResults" />
 }
 else {
@@ -95,7 +95,7 @@ else {
                 </div>
             </div>
             <div id="results" class="govuk-grid-column-two-thirds" data-total-results="@Model.TotalResults">
-                @if (!Model.Services.Any())
+                @if (!Model.ServiceDetailList.Any())
                 {
                     <h2 class="govuk-heading-m">
                         Try another search
@@ -110,9 +110,14 @@ else {
                 }
                 else
                 {
-                    foreach (var service in Model.Services)
+                    @* foreach (var service in Model.Services) *@
+                    @* { *@
+                    @*     <partial name="_Service" model='service'/> *@
+                    @* } *@
+
+                    foreach (ServiceDetail serviceDetail in Model.ServiceDetailList)
                     {
-                        <partial name="_Service" model='service'/>
+                        @await Html.PartialAsync(serviceDetail.ServiceDetailType == ServiceDetailType.Service ? "_service" : "_location", serviceDetail)
                     }
 
                     <partial name="_LargeSetPaginationForm" model='Model.Pagination' />

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml
@@ -110,11 +110,6 @@ else {
                 }
                 else
                 {
-                    @* foreach (var service in Model.Services) *@
-                    @* { *@
-                    @*     <partial name="_Service" model='service'/> *@
-                    @* } *@
-
                     foreach (ServiceDetail serviceDetail in Model.ServiceDetailList)
                     {
                         @await Html.PartialAsync(serviceDetail.ServiceDetailType == ServiceDetailType.Service ? "_service" : "_location", serviceDetail)

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml.cs
@@ -269,7 +269,10 @@ public class ServiceFilterModel : PageModel
 
             Pagination = new LargeSetPagination(serviceDtoListPaginated.List.TotalPages + locationDtoListPaginated.TotalPages, CurrentPage);
 
-            ServiceDetailList = ServiceDetailList.Concat(serviceList).Concat(locationList);
+            ServiceDetailList = ServiceDetailList
+                .Concat(serviceList)
+                .Concat(locationList)
+                .OrderBy(x => x.Distance);
 
             // (PaginatedList<ServiceDto> paginatedServices, Pagination, HttpResponseMessage? response)
             //     = await GetServicesAndPagination(adminArea, latitude, longitude);

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml.cs
@@ -260,7 +260,7 @@ public class ServiceFilterModel : PageModel
             }
 
             (PaginatedList<ServiceDto> List, HttpResponseMessage? Response) serviceDtoListPaginated = await GetPaginatedServiceList(servicesParams);
-            PaginatedList<LocationDto> locationDtoListPaginated = await GetPaginatedLocationList();
+            PaginatedList<LocationDto> locationDtoListPaginated = await GetPaginatedLocationList(CurrentPage, PageSize);
 
             TotalResults = serviceDtoListPaginated.List.TotalCount + locationDtoListPaginated.TotalCount;
 
@@ -316,7 +316,7 @@ public class ServiceFilterModel : PageModel
         GetPaginatedServiceList(ServicesParams servicesParams) => await _serviceDirectoryClient.GetServices(servicesParams);
 
     private async Task<PaginatedList<LocationDto>>
-        GetPaginatedLocationList() => await _serviceDirectoryClient.GetLocations(true, Latitude, Longitude);
+        GetPaginatedLocationList(int? pageNumber, int? pageSize) => await _serviceDirectoryClient.GetLocations(true, pageNumber, pageSize, Latitude, Longitude);
 
     // private async Task<( // TODO: FHB-805 Remove all this after
     //     PaginatedList<ServiceDto> services,

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml.cs
@@ -276,7 +276,7 @@ public class ServiceFilterModel : PageModel
 
             // (PaginatedList<ServiceDto> paginatedServices, Pagination, HttpResponseMessage? response)
             //     = await GetServicesAndPagination(adminArea, latitude, longitude);
-            // UpdateServicesPagination(paginatedServices);
+            // UpdateServicesPagination(paginatedServices); // TODO: FHB-805 Remove all this after
 
             DateTime? responseTimestamp = serviceDtoListPaginated.Response is not null ? DateTime.UtcNow : null;
 
@@ -316,9 +316,9 @@ public class ServiceFilterModel : PageModel
         GetPaginatedServiceList(ServicesParams servicesParams) => await _serviceDirectoryClient.GetServices(servicesParams);
 
     private async Task<PaginatedList<LocationDto>>
-        GetPaginatedLocationList() => await _serviceDirectoryClient.GetLocations(true);
+        GetPaginatedLocationList() => await _serviceDirectoryClient.GetLocations(true, Latitude, Longitude);
 
-    // private async Task<(
+    // private async Task<( // TODO: FHB-805 Remove all this after
     //     PaginatedList<ServiceDto> services,
     //     IPagination pagination,
     //     HttpResponseMessage? response

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Location.cshtml
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Location.cshtml
@@ -1,0 +1,17 @@
+@model Location
+
+<div class="app-service">
+    <div class="govuk-summary-list__row">
+        <div class="govuk-summary-list__key">
+            @*todo: description on view enum? - think it will come from db*@
+            <span class="govuk-caption-m govuk-!-margin-top-3">Test</span>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0">@Model.Name <span class="govuk-!-font-weight-regular"> (@Model.Distance?.ToString("0.0") miles)</span></h3>
+        </div>
+    </div>
+
+    <dl class="govuk-summary-list govuk-summary-list--no-border">
+
+        <partial name="_SummaryListRows" model='("Where", Model.Address)' />
+        <partial name="_SummaryListRow" model='("More details", Model.MoreDetails)' />
+    </dl>
+</div>

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Service.cshtml
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Service.cshtml
@@ -6,19 +6,16 @@
     <div class="govuk-summary-list__row">
         <div class="govuk-summary-list__key">
             @*todo: description on view enum? - think it will come from db*@
-            <span class="govuk-caption-m govuk-!-margin-top-3">@(Model.Type == ServiceType.FamilyHub ? "Family hub" : "Service and groups")</span>
+            <span class="govuk-caption-m govuk-!-margin-top-3">Service and groups</span>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0">@Model.Name <span class="govuk-!-font-weight-regular"> (@Model.Distance?.ToString("0.0") miles)</span></h3>
         </div>
     </div>
 
     <dl class="govuk-summary-list govuk-summary-list--no-border">
-            
-        @if (Model.Type == ServiceType.Service)
-        {
-            <partial name="_SummaryListRows" model='("Category", Model.Categories)' />
-            <partial name="_SummaryListRow" model='("Age range", Model.AgeRange)' />
-            <partial name="_SummaryListRows" model='("When", Model.When)' />
-        }
+
+        <partial name="_SummaryListRows" model='("Category", Model.Categories)' />
+        <partial name="_SummaryListRow" model='("Age range", Model.AgeRange)' />
+        <partial name="_SummaryListRows" model='("When", Model.When)' />
 
         <partial name="_SummaryListRows" model='("Where", Model.Where)' />
             
@@ -27,13 +24,6 @@
         <partial name="_SummaryListLink" model='("Email", Model.Email, LinkType.Email, default(string?))' />
         <partial name="_SummaryListLink" model='("Website", Model.WebsiteUrl, LinkType.WebPageInNewTab, Model.WebsiteName)' />
 
-        @if (Model.Type == ServiceType.FamilyHub)
-        {
-            <partial name="_SummaryListRows" model='("Opening hours", Model.When)' />
-        }
-        else
-        {
-            <partial name="_SummaryListRows" model='("Cost", Model.Cost)' />
-        }
+        <partial name="_SummaryListRows" model='("Cost", Model.Cost)' />
     </dl>
 </div>


### PR DESCRIPTION
**As discussed in the team meeting 25/10/2024, the complexities uncovered whilst working on this PR mean that this work will be paused as it will require extensive changes beyond the scope of a single ticket / PR**

Ticket: [FHB-805](https://dfedigital.atlassian.net/browse/FHB-805)

---

This PR

- Stops displaying services that exist at family hubs as a special "Family Hub" category, as this is actually incorrect behaviour - they are all services (i.e., "Services and groups" in the front-end)
- Displays Family Hubs locations alongside the services, as this is the intended behaviour. So basically Find displays services + locations (where the locations are == family hubs) instead of just services.

[FHB-805]: https://dfedigital.atlassian.net/browse/FHB-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ