### PR TITLE
FHB-833:  list of services connect

### DIFF
--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Core/Queries/Services/GetServices/GetServicesCommand.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Core/Queries/Services/GetServices/GetServicesCommand.cs
@@ -112,6 +112,7 @@ public class GetServicesCommandHandler : IRequestHandler<GetServicesCommand, Pag
             .Join(FhJoin.Type.Left, "[Languages] la", "s.Id = la.ServiceId")
             .Join(FhJoin.Type.Left, "[Eligibilities] e", "s.Id = e.ServiceId")
             .Join(FhJoin.Type.Left, "[CostOptions] co", "s.Id = co.ServiceId")
+            .Join(FhJoin.Type.Left, "[ServiceDeliveries] sd", "s.Id = sd.ServiceId")
             .Join(FhJoin.Type.Left, "[Schedules] ls", "sl.Id = ls.ServiceAtLocationId")
             .Join(FhJoin.Type.Left, "[Schedules] ss", "s.Id = ss.ServiceId")
             .GroupBy("s.Id")
@@ -154,9 +155,7 @@ public class GetServicesCommandHandler : IRequestHandler<GetServicesCommand, Pag
                 )
             ).AndNotNull(
                 request.ServiceDeliveries,
-                sd => new InCondition("ss.AttendingType", "ServiceServiceDeliveries", sd).Or(
-                    new InCondition("ls.AttendingType", "LocationServiceDeliveries", sd)
-                )
+                sd => new InCondition("sd.Name", "ServiceServiceDeliveries", sd)
             );
 
         // if 'all children and young people' (for children ticked & all ages),
@@ -228,7 +227,6 @@ public class GetServicesCommandHandler : IRequestHandler<GetServicesCommand, Pag
         var pArr = query.AllParameters(_useSqlite);
         var total = await _context.Database.SqlQueryRaw<long>(query.Format(_useSqlite, includeOrderBy: false, includeLimit: false), pArr).CountAsync(cancellationToken);
         var ids = _context.Database.SqlQueryRaw<long>(query.Format(_useSqlite), pArr);
-
         var joinQuery = _context.Services
             .IgnoreAutoIncludes()
             .AsNoTracking()


### PR DESCRIPTION
The query to get servicesis pointing to the scheduled table to get the service deliveries. This is correct in that this table should be being used IF it's previous migrations and implementation was complete, which is has not been. SO we can point to the ServiceDeliveries table for now and look at switching it back over later.
Verified that the query now returns the same number of results with all 3 filters and without any.