### PR TITLE
Ignore local/db/sql folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ x86/
 build/
 bld/
 [Bb]in/
+[Oo]bj/
 [Oo]ut/
 msbuild.log
 msbuild.err

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,5 @@ bld/
 msbuild.log
 msbuild.err
 msbuild.wrn
-msbuild.wrn
 
 local/db/sql 

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,10 @@ x86/
 build/
 bld/
 [Bb]in/
-[Oo]bj/
 [Oo]ut/
 msbuild.log
 msbuild.err
 msbuild.wrn
+msbuild.wrn
+
+local/db/sql 


### PR DESCRIPTION
We don't want any of the files that are auto-generated when a developer uses the `docker-compose.yml` file in here showing up in git.