### PR TITLE
Change docker container name

### DIFF
--- a/local/db/docker-compose.yml
+++ b/local/db/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3.8'
+name: 'family-hubs'
 services:
   mssql:
     image: mcr.microsoft.com/mssql/server:2022-latest


### PR DESCRIPTION
Docker containers now live under a parent called 'Family Hubs'

![Screenshot 2024-10-31 at 13 30 10](https://github.com/user-attachments/assets/41a331b1-ef4b-4ea6-88dc-01f62a2563d0)
