### PR TITLE
FHB-712 : Fix Double URL Encoding

### DIFF
--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Service.cshtml
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Service.cshtml
@@ -1,4 +1,5 @@
-﻿@using Microsoft.AspNetCore.Http.Extensions
+﻿@using System.Web
+@using Microsoft.AspNetCore.Http.Extensions
 @model Service
 
 @* todo: use summary list tag helpers *@
@@ -6,7 +7,7 @@
 <div class="app-service">
     <div class="govuk-summary-list__row">
         <div class="govuk-summary-list__key">
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><a asp-page="/ServiceDetail/Index" asp-route-serviceId="@Model.ServiceId" asp-route-fromUrl="@Context.Request.GetEncodedPathAndQuery()">@Model.Name</a> <span class="govuk-!-font-weight-regular"> (@Model.Distance?.ToString("0.0") miles)</span></h3>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><a asp-page="/ServiceDetail/Index" asp-route-serviceId="@Model.ServiceId" asp-route-fromUrl="@HttpUtility.UrlDecode(Context.Request.GetEncodedPathAndQuery())">@Model.Name</a> <span class="govuk-!-font-weight-regular"> (@Model.Distance?.ToString("0.0") miles)</span></h3>
         </div>
     </div>
 


### PR DESCRIPTION
Ticket: [FHB-712](https://dfedigital.atlassian.net/browse/FHB-712)

---

This PR:

- Fixes an issue the WAF flagged where there is a double encoding with the space character when the postcode has a space in it, e.g., the pre-encoded %20 became %2520 (as the % sign has ASCII %25) and this made the WAF sad, so it's now fully decoded before being re-encoded.

[FHB-712]: https://dfedigital.atlassian.net/browse/FHB-712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ