### PR TITLE
FHB-908:  margin

### DIFF
--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Service.cshtml
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Service.cshtml
@@ -7,7 +7,7 @@
 <div class="app-service">
     <div class="govuk-summary-list__row">
         <div class="govuk-summary-list__key">
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><a asp-page="/ServiceDetail/Index" asp-route-serviceId="@Model.ServiceId" asp-route-fromUrl="@HttpUtility.UrlDecode(Context.Request.GetEncodedPathAndQuery())">@Model.Name</a> <span class="govuk-!-font-weight-regular"> (@Model.Distance?.ToString("0.0") miles)</span></h3>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-3"><a asp-page="/ServiceDetail/Index" asp-route-serviceId="@Model.ServiceId" asp-route-fromUrl="@HttpUtility.UrlDecode(Context.Request.GetEncodedPathAndQuery())">@Model.Name</a> <span class="govuk-!-font-weight-regular"> (@Model.Distance?.ToString("0.0") miles)</span></h3>
         </div>
     </div>
 


### PR DESCRIPTION
Fix an issue with the margin being removed from an old element by adding it to the h3 header of the service link. Produces the same effect.