### PR TITLE
Add flag to reset and reseed databases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ on:
           - 'Test2'
           - 'Pre-production'
           - 'Production'
+      reset_and_reseed_databases:
+        description: Choose to reset all the databases and reseed
+        default: true
+        type: boolean
 
 permissions:
   id-token: write
@@ -88,7 +92,7 @@ jobs:
       dotnet_version: ${{ matrix.dotnet_version_override || vars.DOTNET_VERSION }}
 
   reset-databases:
-    if: startsWith(inputs.environment, 'Test')
+    if: startsWith(inputs.environment, 'Test') && inputs.reset_and_reseed_databases
     name: Reset the ${{ matrix.display_name }} database
     needs: [ build-projects-upload-artifacts ]
     strategy:
@@ -278,7 +282,7 @@ jobs:
     secrets: inherit
   
   seed-databases:
-    if: startsWith(inputs.environment, 'Test')
+    if: startsWith(inputs.environment, 'Test') && inputs.reset_and_reseed_databases
     name: Seed the ${{ matrix.display_name }} database
     needs: [ deploy-api-services, deploy-ui-services, deploy-functions ]
     strategy:


### PR DESCRIPTION
A flag to the deployment pipeline to allow testers to choose to reset and reseed databases as there is a valid use case for not doing it, if for example, they want to retest a ticket with a fix but don't want to re-create data they had previously created whilst testing.