### PR TITLE
feat(APIs): Remove IIS headers. Add security headers

### DIFF
--- a/src/service/idam-api/src/FamilyHubs.Idam.Api/StartupExtensions.cs
+++ b/src/service/idam-api/src/FamilyHubs.Idam.Api/StartupExtensions.cs
@@ -144,6 +144,7 @@ public static class StartupExtensions
         webApplication.UseSwaggerUI();
 
         webApplication.UseHttpsRedirection();
+        webApplication.UseHsts();
 
         webApplication.MapControllers();
 

--- a/src/service/idam-api/src/FamilyHubs.Idam.Api/web.config
+++ b/src/service/idam-api/src/FamilyHubs.Idam.Api/web.config
@@ -1,0 +1,18 @@
+<configuration>
+    <system.webServer>
+        <httpProtocol>
+            <customHeaders>
+                <add name="X-Frame-Options" value="DENY" />
+                <add name="X-XSS-Protection" value="1; mode=block" />
+                <add name="X-Content-Type-Options" value="nosniff" />
+                <add name="Content-Security-Policy" value="default-src 'none';" />
+
+                <remove name="X-Powered-By" />
+                <remove name="x-aspnet-version"/>
+            </customHeaders>
+        </httpProtocol>
+        <security>
+            <requestFiltering removeServerHeader="true" />
+        </security>
+    </system.webServer>
+</configuration>

--- a/src/service/mock-hsda-api/src/FamilyHubs.Mock-Hsda.Api/Program.cs
+++ b/src/service/mock-hsda-api/src/FamilyHubs.Mock-Hsda.Api/Program.cs
@@ -57,6 +57,7 @@ app.UseSwaggerUI(c =>
 });
 
 app.UseHttpsRedirection();
+app.UseHsts();
 
 app.UseRouting();
 

--- a/src/service/mock-hsda-api/src/FamilyHubs.Mock-Hsda.Api/web.config
+++ b/src/service/mock-hsda-api/src/FamilyHubs.Mock-Hsda.Api/web.config
@@ -1,0 +1,18 @@
+<configuration>
+    <system.webServer>
+        <httpProtocol>
+            <customHeaders>
+                <add name="X-Frame-Options" value="DENY" />
+                <add name="X-XSS-Protection" value="1; mode=block" />
+                <add name="X-Content-Type-Options" value="nosniff" />
+                <add name="Content-Security-Policy" value="default-src 'none';" />
+
+                <remove name="X-Powered-By" />
+                <remove name="x-aspnet-version"/>
+            </customHeaders>
+        </httpProtocol>
+        <security>
+            <requestFiltering removeServerHeader="true" />
+        </security>
+    </system.webServer>
+</configuration>

--- a/src/service/notification-api/src/FamilyHubs.Notification.Api/Endpoints/MinimalNotifyEndPoints.cs
+++ b/src/service/notification-api/src/FamilyHubs.Notification.Api/Endpoints/MinimalNotifyEndPoints.cs
@@ -1,4 +1,5 @@
-﻿using FamilyHubs.Notification.Core.Commands.CreateNotification;
+﻿using System.Net.Mime;
+using FamilyHubs.Notification.Core.Commands.CreateNotification;
 using FamilyHubs.Notification.Core.Queries.GetSentNotifications;
 using FamilyHubs.Notification.Api.Contracts;
 using MediatR;
@@ -26,7 +27,9 @@ public class MinimalNotifyEndPoints
             var result = await _mediator.Send(request, cancellationToken);
             return result;
 
-        }).WithMetadata(new SwaggerOperationAttribute("Get Notifications", "Get Paginated Notification List") { Tags = new[] { "Notifications" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Notifications", "Get Paginated Notification List") { Tags = new[] { "Notifications" } })
+            .Produces<PaginatedList<MessageDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/notify/{id}", [Authorize] async (long id, CancellationToken cancellationToken, ISender _mediator) =>
         {
@@ -34,6 +37,8 @@ public class MinimalNotifyEndPoints
             var result = await _mediator.Send(request, cancellationToken);
             return result;
 
-        }).WithMetadata(new SwaggerOperationAttribute("Get Notification By Id", "Get Notification By Id") { Tags = new[] { "Notifications" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Notification By Id", "Get Notification By Id") { Tags = new[] { "Notifications" } })
+            .Produces<MessageDto>(contentType: MediaTypeNames.Application.Json);
     }
 }

--- a/src/service/notification-api/src/FamilyHubs.Notification.Api/StartupExtensions.cs
+++ b/src/service/notification-api/src/FamilyHubs.Notification.Api/StartupExtensions.cs
@@ -178,6 +178,7 @@ public static class StartupExtensions
         webApplication.UseSwaggerUI();
 
         webApplication.UseHttpsRedirection();
+        webApplication.UseHsts();
 
         webApplication.MapControllers();
 

--- a/src/service/notification-api/src/FamilyHubs.Notification.Api/web.config
+++ b/src/service/notification-api/src/FamilyHubs.Notification.Api/web.config
@@ -1,0 +1,18 @@
+<configuration>
+    <system.webServer>
+        <httpProtocol>
+            <customHeaders>
+                <add name="X-Frame-Options" value="DENY" />
+                <add name="X-XSS-Protection" value="1; mode=block" />
+                <add name="X-Content-Type-Options" value="nosniff" />
+                <add name="Content-Security-Policy" value="default-src 'none';" />
+
+                <remove name="X-Powered-By" />
+                <remove name="x-aspnet-version"/>
+            </customHeaders>
+        </httpProtocol>
+        <security>
+            <requestFiltering removeServerHeader="true" />
+        </security>
+    </system.webServer>
+</configuration>

--- a/src/service/referral-api/src/FamilyHubs.Referral.Api/Endpoints/MinimalReferralEndPoints.cs
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Api/Endpoints/MinimalReferralEndPoints.cs
@@ -1,4 +1,5 @@
-﻿using FamilyHubs.Referral.Core.Commands.CreateReferral;
+﻿using System.Net.Mime;
+using FamilyHubs.Referral.Core.Commands.CreateReferral;
 using FamilyHubs.Referral.Core.Commands.SetReferralStatus;
 using FamilyHubs.Referral.Core.Commands.UpdateReferral;
 using FamilyHubs.Referral.Core.Queries.GetReferrals;
@@ -13,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Security.Claims;
 using FamilyHubs.ReferralService.Shared.Dto.CreateUpdate;
+using FamilyHubs.ReferralService.Shared.Models;
 
 namespace FamilyHubs.Referral.Api.Endpoints;
 
@@ -32,8 +34,10 @@ public class MinimalReferralEndPoints
                 var result = await mediator.Send(command, cancellationToken);
                 return result;
 
-            }).WithMetadata(new SwaggerOperationAttribute("Referrals", "Create Referral")
-            { Tags = new[] { "Referrals" } });
+            })
+            .WithMetadata(new SwaggerOperationAttribute("Referrals", "Create Referral")
+                { Tags = new[] { "Referrals" } })
+            .Produces<ReferralResponse>(contentType: MediaTypeNames.Application.Json);
 
         app.MapPut("api/referrals/{id}", [Authorize(Policy = "ReferralUser")] async (long id, [FromBody] ReferralDto request, CancellationToken cancellationToken, ISender _mediator, ILogger<MinimalReferralEndPoints> logger) =>
         {
@@ -50,7 +54,9 @@ public class MinimalReferralEndPoints
             var result = await _mediator.Send(request, cancellationToken);
             return result;
 
-        }).WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referrals By Referrer") { Tags = new[] { "Referrals" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referrals By Referrer") { Tags = new[] { "Referrals" } })
+            .Produces<PaginatedList<ReferralDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/referralsByReferrer/{referrerId}", [Authorize(Roles = RoleGroups.LaProfessionalOrDualRole)] async (long referrerId, ReferralOrderBy? orderBy, bool? isAssending, bool? includeDeclined, int? pageNumber, int? pageSize, CancellationToken cancellationToken, ISender _mediator) =>
         {
@@ -58,7 +64,9 @@ public class MinimalReferralEndPoints
             var result = await _mediator.Send(request, cancellationToken);
             return result;
 
-        }).WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referrals By Referrer Id") { Tags = new[] { "Referrals" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referrals By Referrer Id") { Tags = new[] { "Referrals" } })
+            .Produces<PaginatedList<ReferralDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/organisationreferrals/{organisationId}", [Authorize(Roles = RoleGroups.VcsProfessionalOrDualRole)] async (long organisationId, ReferralOrderBy? orderBy, bool? isAssending, bool? includeDeclined, int? pageNumber, int? pageSize, CancellationToken cancellationToken, ISender _mediator) =>
         {
@@ -66,7 +74,9 @@ public class MinimalReferralEndPoints
             var result = await _mediator.Send(request, cancellationToken);
             return result;
 
-        }).WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referrals By Organisation Id") { Tags = new[] { "Referrals" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referrals By Organisation Id") { Tags = new[] { "Referrals" } })
+            .Produces<PaginatedList<ReferralDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/referral/{id}", [Authorize(Roles = RoleGroups.LaProfessionalOrDualRole+","+RoleGroups.VcsProfessionalOrDualRole+","+ RoleTypes.LaManager)] async (long id, CancellationToken cancellationToken, ISender _mediator, HttpContext httpContext) =>
         {
@@ -92,7 +102,9 @@ public class MinimalReferralEndPoints
 
             return result;
 
-        }).WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referral By Id") { Tags = new[] { "Referrals" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referral By Id") { Tags = new[] { "Referrals" } })
+            .Produces<ReferralDto>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/referral/compositekeys", [Authorize(Policy = "ReferralUser")] async (long? serviceId, long? statusId, long? recipientId, long? referralId, ReferralOrderBy? orderBy, bool? isAssending, bool? includeDeclined, int? pageNumber, int? pageSize, CancellationToken cancellationToken, ISender _mediator) =>
         {
@@ -100,7 +112,9 @@ public class MinimalReferralEndPoints
             var result = await _mediator.Send(request, cancellationToken);
             return result;
 
-        }).WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referral By Composite Keys") { Tags = new[] { "Referrals" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referral By Composite Keys") { Tags = new[] { "Referrals" } })
+            .Produces<PaginatedList<ReferralDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/referral/count",
             [Authorize(Roles = RoleGroups.AdminRole)]
@@ -144,8 +158,9 @@ public class MinimalReferralEndPoints
             GetReferralStatusesCommand request = new();
             var result = await _mediator.Send(request, cancellationToken);
             return result;
-
-        }).WithMetadata(new SwaggerOperationAttribute("Get Referral Statuses", "Get Referral Statuses") { Tags = new[] { "Referrals" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Referral Statuses", "Get Referral Statuses") { Tags = new[] { "Referrals" } })
+            .Produces<List<ReferralStatusDto>>(contentType: MediaTypeNames.Application.Json);
 #pragma warning disable S1481
         app.MapGet("api/referral/recipient", [Authorize(Roles = $"{RoleTypes.LaManager},{RoleTypes.LaProfessional},{RoleTypes.LaDualRole}")] async (string? email, string? telephone, string? textphone, string? name, string? postcode, CancellationToken cancellationToken, ISender _mediator, HttpContext httpContext) =>
         {
@@ -160,7 +175,9 @@ public class MinimalReferralEndPoints
 
             return await SetForbidden<List<ReferralDto>>(httpContext);    
 
-        }).WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referral By Recipient") { Tags = new[] { "Referrals" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Referrals", "Get Referral By Recipient") { Tags = new[] { "Referrals" } })
+            .Produces<List<ReferralDto>>(contentType: MediaTypeNames.Application.Json);
 #pragma warning restore S1481
     }
 

--- a/src/service/referral-api/src/FamilyHubs.Referral.Api/Endpoints/MinimalUserAccountEndPoints.cs
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Api/Endpoints/MinimalUserAccountEndPoints.cs
@@ -1,7 +1,9 @@
-﻿using FamilyHubs.Referral.Core.Commands.CreateUserAccount;
+﻿using System.Net.Mime;
+using FamilyHubs.Referral.Core.Commands.CreateUserAccount;
 using FamilyHubs.Referral.Core.Commands.UpdateUserAccount;
 using FamilyHubs.Referral.Core.Queries.GetUserAccounts;
 using FamilyHubs.ReferralService.Shared.Dto;
+using FamilyHubs.ReferralService.Shared.Models;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -50,6 +52,8 @@ public class MinimalUserAccountEndPoints
             var result = await _mediator.Send(command, cancellationToken);
             return result;
 
-        }).WithMetadata(new SwaggerOperationAttribute("User Accounts", "Get User Accounts By Organisation Id") { Tags = new[] { "User Accounts" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("User Accounts", "Get User Accounts By Organisation Id") { Tags = new[] { "User Accounts" } })
+            .Produces<PaginatedList<UserAccountDto>>(contentType: MediaTypeNames.Application.Json);
     }
 }

--- a/src/service/referral-api/src/FamilyHubs.Referral.Api/StartupExtensions.cs
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Api/StartupExtensions.cs
@@ -198,6 +198,7 @@ public static class StartupExtensions
         webApplication.UseSwaggerUI();
 
         webApplication.UseHttpsRedirection();
+        webApplication.UseHsts();
 
         webApplication.MapControllers();
 

--- a/src/service/referral-api/src/FamilyHubs.Referral.Api/web.config
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Api/web.config
@@ -1,0 +1,18 @@
+<configuration>
+    <system.webServer>
+        <httpProtocol>
+            <customHeaders>
+                <add name="X-Frame-Options" value="DENY" />
+                <add name="X-XSS-Protection" value="1; mode=block" />
+                <add name="X-Content-Type-Options" value="nosniff" />
+                <add name="Content-Security-Policy" value="default-src 'none';" />
+
+                <remove name="X-Powered-By" />
+                <remove name="x-aspnet-version"/>
+            </customHeaders>
+        </httpProtocol>
+        <security>
+            <requestFiltering removeServerHeader="true" />
+        </security>
+    </system.webServer>
+</configuration>

--- a/src/service/report-api/src/FamilyHubs.Report.Api/Endpoints/MinimalAdminReportEndPoints.cs
+++ b/src/service/report-api/src/FamilyHubs.Report.Api/Endpoints/MinimalAdminReportEndPoints.cs
@@ -1,9 +1,12 @@
+using System.Net.Mime;
 using FamilyHubs.Report.Core.Queries.ConnectionRequestsSentFacts;
 using FamilyHubs.Report.Core.Queries.ConnectionRequestsSentFacts.Requests;
 using FamilyHubs.Report.Core.Queries.ServiceSearchFacts;
 using FamilyHubs.Report.Core.Queries.ServiceSearchFacts.Requests;
 using FamilyHubs.ServiceDirectory.Shared.Enums;
 using FamilyHubs.SharedKernel.Identity;
+using FamilyHubs.SharedKernel.Reports.ConnectionRequests;
+using FamilyHubs.SharedKernel.Reports.WeeklyBreakdown;
 using FluentValidation;
 using Microsoft.AspNetCore.Authorization;
 
@@ -41,7 +44,8 @@ public class MinimalAdminReportEndPoints
                 SearchBreakdownRequest request = new(date, serviceTypeId);
                 await validator.ValidateAndThrowAsync(request);
                 return await getFourWeekBreakdownQuery.GetFourWeekBreakdownForAdmin(request);
-            });
+            })
+            .Produces<WeeklyReportBreakdown>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("report/service-searches-total",
             [Authorize(Roles = RoleTypes.DfeAdmin)]
@@ -66,7 +70,8 @@ public class MinimalAdminReportEndPoints
                 ConnectionRequestsRequest request = new(date, 7);
                 await validator.ValidateAndThrowAsync(request);
                 return await getConnectionRequestsSentFactQuery.GetConnectionRequestsForAdmin(request);
-            });
+            })
+            .Produces<ConnectionRequests>(contentType: MediaTypeNames.Application.Json);
 
 
         app.MapGet("report/connection-requests-4-week-breakdown",
@@ -79,12 +84,14 @@ public class MinimalAdminReportEndPoints
                 ConnectionRequestsBreakdownRequest request = new(date);
                 await validator.ValidateAndThrowAsync(request);
                 return await getConnectionRequestsSentFactFourWeekBreakdownQuery.GetFourWeekBreakdownForAdmin(request);
-            });
+            })
+            .Produces<ConnectionRequestsBreakdown>(contentType: MediaTypeNames.Application.Json);
 
 
         app.MapGet("report/connection-requests-total",
             [Authorize(Roles = RoleTypes.DfeAdmin)]
             async (IGetConnectionRequestsSentFactQuery getConnectionRequestsSentFactQuery) =>
-                await getConnectionRequestsSentFactQuery.GetTotalConnectionRequestsForAdmin());
+                await getConnectionRequestsSentFactQuery.GetTotalConnectionRequestsForAdmin())
+            .Produces<ConnectionRequests>(contentType: MediaTypeNames.Application.Json);
     }
 }

--- a/src/service/report-api/src/FamilyHubs.Report.Api/Endpoints/MinimalOrgReportEndPoints.cs
+++ b/src/service/report-api/src/FamilyHubs.Report.Api/Endpoints/MinimalOrgReportEndPoints.cs
@@ -1,9 +1,12 @@
+using System.Net.Mime;
 using FamilyHubs.Report.Core.Queries.ConnectionRequestsSentFacts;
 using FamilyHubs.Report.Core.Queries.ConnectionRequestsSentFacts.Requests;
 using FamilyHubs.Report.Core.Queries.ServiceSearchFacts;
 using FamilyHubs.Report.Core.Queries.ServiceSearchFacts.Requests;
 using FamilyHubs.ServiceDirectory.Shared.Enums;
 using FamilyHubs.SharedKernel.Identity;
+using FamilyHubs.SharedKernel.Reports.ConnectionRequests;
+using FamilyHubs.SharedKernel.Reports.WeeklyBreakdown;
 using FluentValidation;
 using Microsoft.AspNetCore.Authorization;
 
@@ -43,7 +46,8 @@ public class MinimalOrgReportEndPoints
                 LaSearchBreakdownRequest request = new(date, serviceTypeId, laOrgId);
                 await validator.ValidateAndThrowAsync(request);
                 return await getFourWeekBreakdownQuery.GetFourWeekBreakdownForLa(request);
-            });
+            })
+            .Produces<WeeklyReportBreakdown>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("report/service-searches-total/organisation/{laOrgId:long}",
             [Authorize(Roles = AllowedRoles)] async (
@@ -69,7 +73,8 @@ public class MinimalOrgReportEndPoints
                 OrgConnectionRequestsRequest request = new(orgId, date, 7);
                 await validator.ValidateAndThrowAsync(request);
                 return await getConnectionRequestsSentFactQuery.GetConnectionRequestsForOrg(request);
-            });
+            })
+            .Produces<ConnectionRequests>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("report/connection-requests-4-week-breakdown/organisation/{orgId:long}",
             [Authorize(Roles = AllowedRoles)]
@@ -83,7 +88,8 @@ public class MinimalOrgReportEndPoints
                 OrgConnectionRequestsBreakdownRequest request = new(date, orgId);
                 await validator.ValidateAndThrowAsync(request);
                 return await getConnectionRequestsSentFactFourWeekBreakdownQuery.GetFourWeekBreakdownForOrg(request);
-            });
+            })
+            .Produces<ConnectionRequestsBreakdown>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("report/connection-requests-total/organisation/{orgId:long}",
             [Authorize(Roles = AllowedRoles)]
@@ -95,6 +101,7 @@ public class MinimalOrgReportEndPoints
                 OrgConnectionRequestsTotalRequest request = new(orgId);
                 await validator.ValidateAndThrowAsync(request);
                 return await getConnectionRequestsSentFactQuery.GetTotalConnectionRequestsForOrg(request);
-            });
+            })
+            .Produces<ConnectionRequests>(contentType: MediaTypeNames.Application.Json);
     }
 }

--- a/src/service/report-api/src/FamilyHubs.Report.Api/Program.cs
+++ b/src/service/report-api/src/FamilyHubs.Report.Api/Program.cs
@@ -35,6 +35,7 @@ public class Program
         app.UseSerilogRequestLogging();
         app.UseMiddleware<ExceptionHandlingMiddleware>();
         app.UseHttpsRedirection();
+        app.UseHsts();
         app.UseAuthorization();
         app.MapFamilyHubsHealthChecks(typeof(Program).Assembly);
 

--- a/src/service/report-api/src/FamilyHubs.Report.Api/web.config
+++ b/src/service/report-api/src/FamilyHubs.Report.Api/web.config
@@ -1,0 +1,18 @@
+<configuration>
+    <system.webServer>
+        <httpProtocol>
+            <customHeaders>
+                <add name="X-Frame-Options" value="DENY" />
+                <add name="X-XSS-Protection" value="1; mode=block" />
+                <add name="X-Content-Type-Options" value="nosniff" />
+                <add name="Content-Security-Policy" value="default-src 'none';" />
+
+                <remove name="X-Powered-By" />
+                <remove name="x-aspnet-version"/>
+            </customHeaders>
+        </httpProtocol>
+        <security>
+            <requestFiltering removeServerHeader="true" />
+        </security>
+    </system.webServer>
+</configuration>

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalLocationEndPoints.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalLocationEndPoints.cs
@@ -1,10 +1,12 @@
-﻿using FamilyHubs.ServiceDirectory.Core.Commands.Locations.CreateLocation;
+﻿using System.Net.Mime;
+using FamilyHubs.ServiceDirectory.Core.Commands.Locations.CreateLocation;
 using FamilyHubs.ServiceDirectory.Core.Commands.Locations.UpdateLocation;
 using FamilyHubs.ServiceDirectory.Core.Queries.Locations.GetLocationById;
 using FamilyHubs.ServiceDirectory.Core.Queries.Locations.GetLocationsByOrganisationId;
 using FamilyHubs.ServiceDirectory.Core.Queries.Locations.GetLocationsByServiceId;
 using FamilyHubs.ServiceDirectory.Core.Queries.Locations.ListLocations;
 using FamilyHubs.ServiceDirectory.Shared.Dto;
+using FamilyHubs.ServiceDirectory.Shared.Models;
 using FamilyHubs.SharedKernel.Identity;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -31,7 +33,9 @@ public class MinimalLocationEndPoints
 
                 throw;
             }
-        }).WithMetadata(new SwaggerOperationAttribute("List Locations", "List Locations") { Tags = new[] { "Locations" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("List Locations", "List Locations") { Tags = new[] { "Locations" } })
+            .Produces<PaginatedList<LocationDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/locations/{id}", async (long id, CancellationToken cancellationToken, ISender mediator, ILogger<MinimalLocationEndPoints> logger) =>
         {
@@ -47,7 +51,9 @@ public class MinimalLocationEndPoints
 
                 throw;
             }
-        }).WithMetadata(new SwaggerOperationAttribute("Get Location by Id", "Get Location by Id") { Tags = new[] { "Locations" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Location by Id", "Get Location by Id") { Tags = new[] { "Locations" } })
+            .Produces<LocationDto>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/organisationlocations/{id}", async (long id, int? pageNumber, string? orderByColumn, int? pageSize, bool? isAscending, string? searchName, bool? isFamilyHub, CancellationToken cancellationToken, ISender mediator, ILogger<MinimalLocationEndPoints> logger) =>
         {
@@ -64,7 +70,9 @@ public class MinimalLocationEndPoints
 
                 throw;
             }
-        }).WithMetadata(new SwaggerOperationAttribute("Get Locations by Organisation Id", "Get Location by Organisation Id") { Tags = new[] { "Locations" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Locations by Organisation Id", "Get Location by Organisation Id") { Tags = new[] { "Locations" } })
+            .Produces<PaginatedList<LocationDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/servicelocations/{id}", async (long id, CancellationToken cancellationToken, ISender mediator, ILogger<MinimalLocationEndPoints> logger) =>
         {
@@ -81,7 +89,9 @@ public class MinimalLocationEndPoints
 
                 throw;
             }
-        }).WithMetadata(new SwaggerOperationAttribute("Get Locations by service Id", "Get Location by Service Id") { Tags = new[] { "Locations" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Locations by service Id", "Get Location by Service Id") { Tags = new[] { "Locations" } })
+            .Produces<List<LocationDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapPut("api/locations/{id}",
             [Authorize(Roles = RoleGroups.AdminRole)] async 

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalOrganisationEndPoints.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalOrganisationEndPoints.cs
@@ -1,4 +1,5 @@
-﻿using FamilyHubs.ServiceDirectory.Core.Commands.Organisations.CreateOrganisation;
+﻿using System.Net.Mime;
+using FamilyHubs.ServiceDirectory.Core.Commands.Organisations.CreateOrganisation;
 using FamilyHubs.ServiceDirectory.Core.Commands.Organisations.DeleteOrganisation;
 using FamilyHubs.ServiceDirectory.Core.Commands.Organisations.UpdateOrganisation;
 using FamilyHubs.ServiceDirectory.Core.Queries.Organisations.GetOrganisationAdminAreaById;
@@ -36,7 +37,9 @@ public class MinimalOrganisationEndPoints
                 
                 throw;
             }
-        }).WithMetadata(new SwaggerOperationAttribute("Get Organisation", "Get Organisation By Id") { Tags = new[] { "Organisations" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Organisation", "Get Organisation By Id") { Tags = new[] { "Organisations" } })
+            .Produces<OrganisationDetailsDto>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/organisationAdminCode/{id}", async (long id, CancellationToken cancellationToken, ISender mediator, ILogger<MinimalOrganisationEndPoints> logger) =>
         {
@@ -76,7 +79,8 @@ public class MinimalOrganisationEndPoints
                 
                 throw;
             }
-        }).WithMetadata(new SwaggerOperationAttribute("List Organisations", "List Organisations") { Tags = new[] { "Organisations" } });
+        }).WithMetadata(new SwaggerOperationAttribute("List Organisations", "List Organisations") { Tags = new[] { "Organisations" } })
+        .Produces<List<OrganisationDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapPut("api/organisations/{id}",
             [Authorize(Roles = $"{RoleTypes.DfeAdmin},{RoleTypes.LaManager},{RoleTypes.LaDualRole}")] async 
@@ -134,11 +138,14 @@ public class MinimalOrganisationEndPoints
 
                 throw;
             }
-        }).WithMetadata(
-            new SwaggerOperationAttribute(
-                "List Organisations By Parent", 
-                "Lists Organisations associated with the parent id, also returns parent organisation"
-                ) { Tags = new[] { "Organisations" } });
+        })
+            .WithMetadata(
+                new SwaggerOperationAttribute(
+                    "List Organisations By Parent",
+                    "Lists Organisations associated with the parent id, also returns parent organisation"
+                    ) { Tags = new[] { "Organisations" } }
+            )
+            .Produces<List<OrganisationDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapDelete("api/organisations/{id}",
             [Authorize(Roles = $"{RoleTypes.DfeAdmin},{RoleTypes.LaManager},{RoleTypes.LaDualRole}")] async

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalServiceEndPoints.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalServiceEndPoints.cs
@@ -1,11 +1,14 @@
-﻿using FamilyHubs.ServiceDirectory.Core.Commands.Services.CreateService;
+﻿using System.Net.Mime;
+using FamilyHubs.ServiceDirectory.Core.Commands.Services.CreateService;
 using FamilyHubs.ServiceDirectory.Core.Commands.Services.DeleteService;
 using FamilyHubs.ServiceDirectory.Core.Commands.Services.UpdateService;
 using FamilyHubs.ServiceDirectory.Core.Queries.Services.GetServiceById;
 using FamilyHubs.ServiceDirectory.Core.Queries.Services.GetServices;
 using FamilyHubs.ServiceDirectory.Core.Queries.Services.GetServicesByOrganisationId;
 using FamilyHubs.ServiceDirectory.Shared.CreateUpdateDto;
+using FamilyHubs.ServiceDirectory.Shared.Dto;
 using FamilyHubs.ServiceDirectory.Shared.Enums;
+using FamilyHubs.ServiceDirectory.Shared.Models;
 using FamilyHubs.SharedKernel.Identity;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -39,8 +42,9 @@ public class MinimalServiceEndPoints
                 allChildrenYoungPeople, givenAge, latitude, longitude, proximity, pageNumber, pageSize, text,
                 serviceDeliveries, isPaidFor, taxonomyIds, languages, canFamilyChooseLocation, isFamilyHub, days);
             return mediator.Send(command, cancellationToken);
-
-        }).WithMetadata(new SwaggerOperationAttribute("List Services", "List Services") { Tags = new[] { "Services" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("List Services", "List Services") { Tags = new[] { "Services" } })
+            .Produces<PaginatedList<ServiceDto>>(contentType: MediaTypeNames.Application.Json);
 
         app.MapGet("api/services-simple/{id}", async (long id, CancellationToken cancellationToken, ISender mediator, ILogger<MinimalServiceEndPoints> logger) =>
         {
@@ -60,7 +64,9 @@ public class MinimalServiceEndPoints
                 
                 throw;
             }
-        }).WithMetadata(new SwaggerOperationAttribute("Get Service by Id", "Get Service by Id") { Tags = new[] { "Services" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Service by Id", "Get Service by Id") { Tags = new[] { "Services" } })
+            .Produces<ServiceDto>(contentType: MediaTypeNames.Application.Json);
 
         //todo: are there any other consumers? if not, change to simple (or summary)
         //todo: this looks like old code
@@ -82,7 +88,9 @@ public class MinimalServiceEndPoints
 
                 throw;
             }
-        }).WithMetadata(new SwaggerOperationAttribute("Get Service by Id", "Get Service by Id") { Tags = new[] { "Services" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get Service by Id", "Get Service by Id") { Tags = new[] { "Services" } })
+            .Produces<ServiceDto>(contentType: MediaTypeNames.Application.Json);
 
         //todo: provide default for all params?
         app.MapGet("api/services/summary", 
@@ -99,7 +107,9 @@ public class MinimalServiceEndPoints
             };
             return await mediator.Send(command, cancellationToken);
 
-        }).WithMetadata(new SwaggerOperationAttribute("Get service names", "Get service names, optionally by Organisation Id") { Tags = new[] { "Services" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get service names", "Get service names, optionally by Organisation Id") { Tags = new[] { "Services" } })
+            .Produces<ServiceNameDto>(contentType: MediaTypeNames.Application.Json);
 
         //todo: check with rider's ef core analyzer
         app.MapPut("api/services/{id}", [Authorize(Roles = RoleGroups.AdminRole)] async 

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalTaxonomyEndPoints.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalTaxonomyEndPoints.cs
@@ -1,8 +1,10 @@
-﻿using FamilyHubs.ServiceDirectory.Core.Commands.Taxonomies.CreateTaxonomy;
+﻿using System.Net.Mime;
+using FamilyHubs.ServiceDirectory.Core.Commands.Taxonomies.CreateTaxonomy;
 using FamilyHubs.ServiceDirectory.Core.Commands.Taxonomies.UpdateTaxonomy;
 using FamilyHubs.ServiceDirectory.Core.Queries.Taxonomies.GetTaxonomies;
 using FamilyHubs.ServiceDirectory.Shared.Dto;
 using FamilyHubs.ServiceDirectory.Shared.Enums;
+using FamilyHubs.ServiceDirectory.Shared.Models;
 using FamilyHubs.SharedKernel.Identity;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -16,10 +18,10 @@ public class MinimalTaxonomyEndPoints
     public void RegisterTaxonomyEndPoints(WebApplication app)
     {
         app.MapPost("api/taxonomies",
-            [Authorize(Roles = $"{RoleTypes.DfeAdmin},{RoleTypes.LaManager},{RoleTypes.LaDualRole}")] async 
-            ([FromBody] TaxonomyDto request, 
-            CancellationToken cancellationToken, 
-            ISender mediator, 
+            [Authorize(Roles = $"{RoleTypes.DfeAdmin},{RoleTypes.LaManager},{RoleTypes.LaDualRole}")] async
+            ([FromBody] TaxonomyDto request,
+            CancellationToken cancellationToken,
+            ISender mediator,
             ILogger<MinimalTaxonomyEndPoints> logger) =>
         {
             try
@@ -31,7 +33,7 @@ public class MinimalTaxonomyEndPoints
             catch (Exception ex)
             {
                 logger.LogError(ex, "An error occurred creating taxonomy. {ExceptionMessage}", ex.Message);
-                
+
                 throw;
             }
         }).WithMetadata(new SwaggerOperationAttribute("Taxonomy", "Create Taxonomy") { Tags = new[] { "Taxonomies" } });
@@ -72,6 +74,8 @@ public class MinimalTaxonomyEndPoints
                 
                 throw;
             }
-        }).WithMetadata(new SwaggerOperationAttribute("Get All Taxonomies", "Get All Taxonomies") { Tags = new[] { "Taxonomies" } });
+        })
+            .WithMetadata(new SwaggerOperationAttribute("Get All Taxonomies", "Get All Taxonomies") { Tags = new[] { "Taxonomies" } })
+            .Produces<PaginatedList<TaxonomyDto>>(contentType: MediaTypeNames.Application.Json);
     }
 }

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Properties/launchSettings.json
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Properties/launchSettings.json
@@ -18,13 +18,6 @@
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "applicationUrl": "https://localhost:7022;http://localhost:5063"
-        },
-        "IIS Express": {
-            "commandName": "IISExpress",
-            "launchBrowser": true,
-            "environmentVariables": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            }
         }
     },
     "$schema": "https://json.schemastore.org/launchsettings.json",

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Properties/launchSettings.json
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/Properties/launchSettings.json
@@ -18,6 +18,13 @@
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "applicationUrl": "https://localhost:7022;http://localhost:5063"
+        },
+        "IIS Express": {
+            "commandName": "IISExpress",
+            "launchBrowser": true,
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
         }
     },
     "$schema": "https://json.schemastore.org/launchsettings.json",

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/StartupExtensions.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/StartupExtensions.cs
@@ -157,6 +157,7 @@ public static class StartupExtensions
         webApplication.UseSwaggerUI();
 
         webApplication.UseHttpsRedirection();
+        webApplication.UseHsts();
 
         webApplication.MapControllers();
         webApplication.MapFamilyHubsHealthChecks(typeof(StartupExtensions).Assembly);

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/web.config
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/web.config
@@ -1,0 +1,18 @@
+<configuration>
+    <system.webServer>
+        <httpProtocol>
+            <customHeaders>
+                <add name="X-Frame-Options" value="DENY" />
+                <add name="X-XSS-Protection" value="1; mode=block" />
+                <add name="X-Content-Type-Options" value="nosniff" />
+                <add name="Content-Security-Policy" value="default-src 'none';" />
+
+                <remove name="X-Powered-By" />
+                <remove name="x-aspnet-version"/>
+            </customHeaders>
+        </httpProtocol>
+        <security>
+            <requestFiltering removeServerHeader="true" />
+        </security>
+    </system.webServer>
+</configuration>


### PR DESCRIPTION
Using web.config means we can actually remove the Server header but doesn't work with Kestrel (which I use locally due to not being on windows) but should be fine in Azure.