### PR TITLE
FHB-117 : Fix Static Page

### DIFF
--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/FamilyHubsLayoutModel.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/FamilyHubsLayoutModel.cs
@@ -13,5 +13,7 @@ public class FamilyHubsLayoutModel
         FamilyHubsUiOptions = familyHubsUiOptions;
     }
 
+    public bool IsError { get; set; }
+
     public PageModel? PageModel { get; set; }
 }

--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/Options/FamilyHubsUiOptions.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/Options/FamilyHubsUiOptions.cs
@@ -55,8 +55,6 @@ public class FamilyHubsUiOptions : IFamilyHubsUiOptions
         return alternativeFamilyHubsUi;
     }
 
-    public bool IsError { get; set; }
-
     /// <summary>
     /// Returns an absolute URL from the Urls config section/dictionary, with an optional relativeUrl applied to the base..
     /// </summary>

--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/Options/IFamilyHubsUiOptions.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/Options/IFamilyHubsUiOptions.cs
@@ -29,7 +29,6 @@ public interface IFamilyHubsUiOptions
     FooterOptions Footer { get; set; }
 
     FamilyHubsUiOptions GetAlternative(string serviceName);
-    bool IsError { get; set; }
 
     Uri Url<TUrlKeyEnum>(TUrlKeyEnum baseUrl, string? relativeUrl = null)
         where TUrlKeyEnum : struct, Enum;

--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Layout/ViewStart.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Layout/ViewStart.cs
@@ -24,7 +24,7 @@ public static class ViewStart
 
         if (pageModel is IHasErrorStatePageModel hasErrorStatePageModel)
         {
-            familyHubsLayoutModel.FamilyHubsUiOptions.Value.IsError = hasErrorStatePageModel.Errors.HasErrors;
+            familyHubsLayoutModel.IsError = hasErrorStatePageModel.Errors.HasErrors;
         }
 
         viewData.SetFamilyHubsLayoutModel(familyHubsLayoutModel);

--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Pages/Shared/_Head.cshtml
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Pages/Shared/_Head.cshtml
@@ -1,23 +1,26 @@
-﻿@model FamilyHubs.SharedKernel.Razor.FamilyHubsUi.Options.IFamilyHubsUiOptions
+﻿@model FamilyHubs.SharedKernel.Razor.FamilyHubsUi.FamilyHubsLayoutModel
+@{
+    var familyHubsUiOptions = Model.FamilyHubsUiOptions.Value;
+}
 
-<partial name="_GoogleAnalytics.cshtml" model="Model"/>
-<partial name="_MicrosoftClarity.cshtml" model="Model"/>
+<partial name="_GoogleAnalytics.cshtml" model="familyHubsUiOptions"/>
+<partial name="_MicrosoftClarity.cshtml" model="familyHubsUiOptions"/>
 
 <meta charset="utf-8" />
-<title>@if (Model.IsError) { <text>Error: </text> }@ViewData["Title"] - @Model.ServiceName - GOV.UK</title>
-<meta name="description" content="@Model.ServiceName">
+<title>@if (Model.IsError) { <text>Error: </text> }@ViewData["Title"] - @familyHubsUiOptions.ServiceName - GOV.UK</title>
+<meta name="description" content="@familyHubsUiOptions.ServiceName">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="theme-color" content="#0b0c0c">
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(Model.PathPrefix)/lib/govuk/assets/images/favicon.ico" type="image/x-icon">
-<link rel="mask-icon" href="@(Model.PathPrefix)/lib/govuk/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
-<link rel="apple-touch-icon" sizes="180x180" href="@(Model.PathPrefix)/lib/govuk/assets/images/govuk-apple-touch-icon-180x180.png">
-<link rel="apple-touch-icon" sizes="167x167" href="@(Model.PathPrefix)/lib/govuk/assets/images/govuk-apple-touch-icon-167x167.png">
-<link rel="apple-touch-icon" sizes="152x152" href="@(Model.PathPrefix)/lib/govuk/assets/images/govuk-apple-touch-icon-152x152.png">
-<link rel="apple-touch-icon" href="@(Model.PathPrefix)/lib/govuk/assets/images/govuk-apple-touch-icon.png">
+<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(familyHubsUiOptions.PathPrefix)/lib/govuk/assets/images/favicon.ico" type="image/x-icon">
+<link rel="mask-icon" href="@(familyHubsUiOptions.PathPrefix)/lib/govuk/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
+<link rel="apple-touch-icon" sizes="180x180" href="@(familyHubsUiOptions.PathPrefix)/lib/govuk/assets/images/govuk-apple-touch-icon-180x180.png">
+<link rel="apple-touch-icon" sizes="167x167" href="@(familyHubsUiOptions.PathPrefix)/lib/govuk/assets/images/govuk-apple-touch-icon-167x167.png">
+<link rel="apple-touch-icon" sizes="152x152" href="@(familyHubsUiOptions.PathPrefix)/lib/govuk/assets/images/govuk-apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon" href="@(familyHubsUiOptions.PathPrefix)/lib/govuk/assets/images/govuk-apple-touch-icon.png">
 
-<meta property="og:image" content="@(Model.PathPrefix)/lib/govuk/assets/images/govuk-opengraph-image.png">
+<meta property="og:image" content="@(familyHubsUiOptions.PathPrefix)/lib/govuk/assets/images/govuk-opengraph-image.png">
 
-<link rel="stylesheet" href="@(Model.PathPrefix)/css/application.css" asp-append-version="true" />
+<link rel="stylesheet" href="@(familyHubsUiOptions.PathPrefix)/css/application.css" asp-append-version="true" />

--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Pages/Shared/_Layout.cshtml
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Pages/Shared/_Layout.cshtml
@@ -7,7 +7,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
 <head>
-    <partial name="_Head.cshtml" model="familyHubsUiOptions"/>
+    <partial name="_Head.cshtml" model="familyHubsLayoutModel"/>
     @await RenderSectionAsync("Head", required: false)
 </head>
 


### PR DESCRIPTION
After noticing the `"Error: "` prefix to the tab titles sometimes hung around on unrelated pages, myself and @Top-Cat quickly got it sorted - just needed to move the Error functionality outside of FamilyHubsUiOptions as it seems to be static and update the models on some of the other pages accordingly.