### PR TITLE
FHB-787 : Remove Unused Package Reference

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -43,7 +43,6 @@
     <PackageVersion Include="EncryptColumn.Core" Version="1.0.0" />
     <PackageVersion Include="EntityFramework" Version="6.5.1" />
     <PackageVersion Include="Enums.NET" Version="5.0.0" />
-    <PackageVersion Include="FamilyHubs.SharedKernel.Razor" Version="9.5.1" />
     <PackageVersion Include="Fare" Version="2.2.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentAssertions.Analyzers" Version="0.33.0" />


### PR DESCRIPTION
Ticket: [FHB-787](https://dfedigital.atlassian.net.mcas.ms/browse/FHB-787)

This PR:

- Removes the SharedKernel.Razor NuGet package from `Directory.Packages.props`, the project itself is already project referenced anyway so it looks like this was just accidentally left in the props file.