### PR TITLE
FHB-1031: Fixed Swagger UI which was prevented from displaying assets

### DIFF
--- a/src/service/idam-api/src/FamilyHubs.Idam.Api/web.config
+++ b/src/service/idam-api/src/FamilyHubs.Idam.Api/web.config
@@ -5,7 +5,7 @@
                 <add name="X-Frame-Options" value="DENY" />
                 <add name="X-XSS-Protection" value="1; mode=block" />
                 <add name="X-Content-Type-Options" value="nosniff" />
-                <add name="Content-Security-Policy" value="default-src 'none';" />
+                <add name="Content-Security-Policy" value="default-src 'self';img-src data: https:;object-src 'none'; script-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline';style-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline'; upgrade-insecure-requests;" />
 
                 <remove name="X-Powered-By" />
                 <remove name="x-aspnet-version"/>

--- a/src/service/mock-hsda-api/src/FamilyHubs.Mock-Hsda.Api/web.config
+++ b/src/service/mock-hsda-api/src/FamilyHubs.Mock-Hsda.Api/web.config
@@ -5,7 +5,7 @@
                 <add name="X-Frame-Options" value="DENY" />
                 <add name="X-XSS-Protection" value="1; mode=block" />
                 <add name="X-Content-Type-Options" value="nosniff" />
-                <add name="Content-Security-Policy" value="default-src 'none';" />
+                <add name="Content-Security-Policy" value="default-src 'self';img-src data: https:;object-src 'none'; script-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline';style-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline'; upgrade-insecure-requests;" />
 
                 <remove name="X-Powered-By" />
                 <remove name="x-aspnet-version"/>

--- a/src/service/notification-api/src/FamilyHubs.Notification.Api/web.config
+++ b/src/service/notification-api/src/FamilyHubs.Notification.Api/web.config
@@ -5,7 +5,7 @@
                 <add name="X-Frame-Options" value="DENY" />
                 <add name="X-XSS-Protection" value="1; mode=block" />
                 <add name="X-Content-Type-Options" value="nosniff" />
-                <add name="Content-Security-Policy" value="default-src 'none';" />
+                <add name="Content-Security-Policy" value="default-src 'self';img-src data: https:;object-src 'none'; script-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline';style-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline'; upgrade-insecure-requests;" />
 
                 <remove name="X-Powered-By" />
                 <remove name="x-aspnet-version"/>

--- a/src/service/referral-api/src/FamilyHubs.Referral.Api/web.config
+++ b/src/service/referral-api/src/FamilyHubs.Referral.Api/web.config
@@ -5,7 +5,7 @@
                 <add name="X-Frame-Options" value="DENY" />
                 <add name="X-XSS-Protection" value="1; mode=block" />
                 <add name="X-Content-Type-Options" value="nosniff" />
-                <add name="Content-Security-Policy" value="default-src 'none';" />
+                <add name="Content-Security-Policy" value="default-src 'self';img-src data: https:;object-src 'none'; script-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline';style-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline'; upgrade-insecure-requests;" />
 
                 <remove name="X-Powered-By" />
                 <remove name="x-aspnet-version"/>

--- a/src/service/report-api/src/FamilyHubs.Report.Api/web.config
+++ b/src/service/report-api/src/FamilyHubs.Report.Api/web.config
@@ -5,7 +5,7 @@
                 <add name="X-Frame-Options" value="DENY" />
                 <add name="X-XSS-Protection" value="1; mode=block" />
                 <add name="X-Content-Type-Options" value="nosniff" />
-                <add name="Content-Security-Policy" value="default-src 'none';" />
+                <add name="Content-Security-Policy" value="default-src 'self';img-src data: https:;object-src 'none'; script-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline';style-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline'; upgrade-insecure-requests;" />
 
                 <remove name="X-Powered-By" />
                 <remove name="x-aspnet-version"/>

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/web.config
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Api/web.config
@@ -5,7 +5,7 @@
                 <add name="X-Frame-Options" value="DENY" />
                 <add name="X-XSS-Protection" value="1; mode=block" />
                 <add name="X-Content-Type-Options" value="nosniff" />
-                <add name="Content-Security-Policy" value="default-src 'none';" />
+                <add name="Content-Security-Policy" value="default-src 'self';img-src data: https:;object-src 'none'; script-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline';style-src https://stackpath.bootstrapcdn.com/ 'self' 'unsafe-inline'; upgrade-insecure-requests;" />
 
                 <remove name="X-Powered-By" />
                 <remove name="x-aspnet-version"/>


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/FHB-1031

- Added extended content security policy to account for the Swagger UI assets such as images, JavaScript and libraries used to render it's UI