### PR TITLE
feat(config): Enable app database connectivity using EntraId

### DIFF
--- a/.github/actions/database-migration/action.yml
+++ b/.github/actions/database-migration/action.yml
@@ -20,7 +20,7 @@ inputs:
   az_firewall_rule_name:
     required: true
     type: string
-  general_key_vault:
+  admin_key_vault:
     required: true
     type: string
   keyvault_prefix:
@@ -47,9 +47,8 @@ runs:
     - name: Apply Database Migration
       shell: pwsh
       run:  |-
-        dotnet user-secrets set "AppConfiguration:KeyVaultIdentifier" "${{ inputs.general_key_vault }}" --project ${{ inputs.startup_project_path }}
-        dotnet user-secrets set "AppConfiguration:KeyVaultPrefix" "${{ inputs.keyvault_prefix }}" --project ${{ inputs.startup_project_path }}
-        dotnet ef database update -c ${{ inputs.db_context }} --project ${{ inputs.data_project_path }} --startup-project ${{ inputs.startup_project_path }}
+        $ConnectionString = az keyvault secret show --name PIPELINE-${{ inputs.keyvault_prefix }}-ConnectionString --vault-name ${{ inputs.admin_key_vault }} --query value --output tsv
+        dotnet ef database update -c ${{ inputs.db_context }} --project ${{ inputs.data_project_path }} --startup-project ${{ inputs.startup_project_path }} --connection $ConnectionString
 
     - name: Remove Azure Firewall Rule
       if: always()

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -9,9 +9,12 @@ on:
       artifact_name:
         required: true
         type: string
-      keyvault_prefix:
+      keyvault_app_prefix:
         required: true
         type: string
+      keyvault_db_prefix:
+        required: true
+        type: string  
       project_name:
         required: true
         type: string
@@ -77,14 +80,14 @@ jobs:
           azure_resource_group: ${{ env.RESOURCE_GROUP }}
           azure_sql_server_resource_name: ${{ env.SQL_SERVER }}
           az_firewall_rule_name: ${{ inputs.artifact_name }}
-          general_key_vault: ${{ env.KEYVAULT }}
-          keyvault_prefix: ${{ inputs.keyvault_prefix }}
+          admin_key_vault: ${{ env.KEYVAULT }}
+          keyvault_prefix: ${{ inputs.keyvault_db_prefix }}
 
       - name: Fetch Publish Profile
         id: fetch_profile
         shell: pwsh
         run: |-
-          $PublishProfile = az keyvault secret show --name ${{ inputs.keyvault_prefix }}-AZURE-WEBAPP-PUBLISH-PROFILE --vault-name ${{ env.KEYVAULT }} --query value --output tsv
+          $PublishProfile = az keyvault secret show --name ${{ inputs.keyvault_app_prefix }}-AZURE-WEBAPP-PUBLISH-PROFILE --vault-name ${{ env.KEYVAULT }} --query value --output tsv
           Write-Output "publish_profile=$PublishProfile" >> $env:GITHUB_OUTPUT
             
       - name: Deploy Artifact to Azure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,42 +150,48 @@ jobs:
         include:
           - artifact_name: idam-api
             job_name: Deploy - IDAM API
-            keyvault_prefix: IDAM-API
+            keyvault_app_prefix: IDAM-API
+            keyvault_db_prefix: IDAM-DB
             project_name: FamilyHubs.Idam.Api
             data_project_name: FamilyHubs.Idam.Data
             database_context: ApplicationDbContext
             azure_app_name: as-fh-idam-api
           - artifact_name: notification-api
             job_name: Deploy - Notification API
-            keyvault_prefix: NOTIFICATIONS-API
+            keyvault_app_prefix: NOTIFICATIONS-API
+            keyvault_db_prefix: NOTIFICATIONS-DB
             project_name: FamilyHubs.Notification.Api
             data_project_name: FamilyHubs.Notification.Data
             database_context: ApplicationDbContext
             azure_app_name: as-fh-notification-api
           - artifact_name: referral-api
             job_name: Deploy - Referral API
-            keyvault_prefix: REFERRAL-API
+            keyvault_app_prefix: REFERRAL-API
+            keyvault_db_prefix: REFERRAL-DB
             project_name: FamilyHubs.Referral.Api
             data_project_name: FamilyHubs.Referral.Data
             database_context: ApplicationDbContext
             azure_app_name: as-fh-referral-api
           - artifact_name: report-api
             job_name: Deploy - Report API
-            keyvault_prefix: REPORT-API
+            keyvault_app_prefix: REPORT-API
+            keyvault_db_prefix: REPORT-DB
             project_name: FamilyHubs.Report.Api
             data_project_name: FamilyHubs.Report.Data
             database_context: ReportDbContext
             azure_app_name: as-fh-report-api
           - artifact_name: service-directory-api
             job_name: Deploy - Service Directory API
-            keyvault_prefix: SD-API
+            keyvault_app_prefix: SD-API
+            keyvault_db_prefix: SD-DB
             project_name: FamilyHubs.ServiceDirectory.Api
             data_project_name: FamilyHubs.ServiceDirectory.Data
             database_context: ApplicationDbContext
             azure_app_name: as-fh-sd-api
           - artifact_name: mock-hsda-api
             job_name: Deploy - Mock HSDA API
-            keyvault_prefix: MOCK-HSDA-API
+            keyvault_app_prefix: MOCK-HSDA-API
+            keyvault_db_prefix: MOCK-HSDA-DB
             project_name: FamilyHubs.Mock-Hsda.Api
             data_project_name: FamilyHubs.Mock-Hsda.Api
             database_context: MockDbContext
@@ -194,7 +200,8 @@ jobs:
     with:
       environment: ${{ inputs.environment }}
       artifact_name: ${{ matrix.artifact_name }}
-      keyvault_prefix: ${{ matrix.keyvault_prefix }}
+      keyvault_app_prefix: ${{ matrix.keyvault_app_prefix }}
+      keyvault_db_prefix: ${{ matrix.keyvault_db_prefix }}
       project_name: ${{ matrix.project_name }}
       data_project_name: ${{ matrix.data_project_name }}
       database_context: ${{ matrix.database_context }}
@@ -217,38 +224,38 @@ jobs:
         include:
           - artifact_name: connect-dashboard-ui
             job_name: Deploy - Connect Dashboard UI
-            keyvault_prefix: CONNECT-DASHBOARD-UI
+            keyvault_app_prefix: CONNECT-DASHBOARD-UI
             project_name: FamilyHubs.RequestForSupport.Web
             azure_app_name: as-fh-ref-dash-ui
 
           - artifact_name: connect-ui
             job_name: Deploy - Connect UI
-            keyvault_prefix: CONNECT-UI
+            keyvault_app_prefix: CONNECT-UI
             project_name: FamilyHubs.Referral.Web
             azure_app_name: as-fh-referral-ui
 
           - artifact_name: find-ui
             job_name: Deploy - Find UI
-            keyvault_prefix: FIND-UI
+            keyvault_app_prefix: FIND-UI
             project_name: FamilyHubs.ServiceDirectory.Web
             azure_app_name: as-fh-sd-ui
 
           - artifact_name: idam-maintenance-ui
             job_name: Deploy - IDAM Maintenance UI
-            keyvault_prefix: IDAM-MAINTENANCE-UI
+            keyvault_app_prefix: IDAM-MAINTENANCE-UI
             project_name: FamilyHubs.Idams.Maintenance.UI
             azure_app_name: as-fh-idam-maintenance-ui
 
           - artifact_name: manage-ui
             job_name: Deploy - Manage UI
-            keyvault_prefix: MANAGE-UI
+            keyvault_app_prefix: MANAGE-UI
             project_name: FamilyHubs.ServiceDirectory.Admin.Web
             azure_app_name: as-fh-sd-admin-ui
     uses: ./.github/workflows/deploy-service.yml
     with:
       environment: ${{ inputs.environment }}
       artifact_name: ${{ matrix.artifact_name }}
-      keyvault_prefix: ${{ matrix.keyvault_prefix }}
+      keyvault_app_prefix: ${{ matrix.keyvault_app_prefix }}
       project_name: ${{ matrix.project_name }}
       project_type: ui
       azure_app_name: ${{ matrix.azure_app_name }}

--- a/terraform/modules/fhinfrastructurestack/fh-report-api-app.tf
+++ b/terraform/modules/fhinfrastructurestack/fh-report-api-app.tf
@@ -5,11 +5,12 @@ resource "azurerm_windows_web_app" "fh_report_api" {
   app_settings = {
     ApplicationInsightsAgent_EXTENSION_VERSION  = "~3"
     XDT_MicrosoftApplicationInsights_Mode       = "Recommended"
-    ASPNETCORE_ENVIRONMENT                      = "${var.asp_netcore_environment}"
+    ASPNETCORE_ENVIRONMENT                      = var.asp_netcore_environment
     WEBSITE_RUN_FROM_PACKAGE                    = "1"
     APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier"       = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix"           = "REPORT-API"
+    "ConnectionStrings:ReportConnection"        = local.report_db_connection
   }
   name                                          = "${var.prefix}-as-fh-report-api"
   resource_group_name                           = local.resource_group_name
@@ -25,8 +26,8 @@ resource "azurerm_windows_web_app" "fh_report_api" {
     ftps_state                                  = "Disabled"
     health_check_path                           = "/api/health"
     application_stack {
-      current_stack                               = "${var.current_stack}"
-      dotnet_version                              = "${var.dotnet_version_general}"
+      current_stack                               = var.current_stack
+      dotnet_version                              = var.dotnet_version_general
     }
     ip_restriction {
       name       = "AllowAppAccess"
@@ -94,7 +95,7 @@ resource "azurerm_private_endpoint" "reportapi" {
 
   ip_configuration {
     name                       = "${var.prefix}-as-fh-report-api"
-    private_ip_address         = "${var.private_endpoint_ip_address.report_api_ip}"
+    private_ip_address         = var.private_endpoint_ip_address.report_api_ip
     subresource_name           = "sites" 
   }
 

--- a/terraform/modules/fhinfrastructurestack/fh-report-stg-api-app.tf
+++ b/terraform/modules/fhinfrastructurestack/fh-report-stg-api-app.tf
@@ -9,6 +9,11 @@ resource "azurerm_mssql_server" "reporting_sql_server" {
   administrator_login = var.sql_server_reporting_user
   administrator_login_password = var.sql_server_reporting_pwd
 
+  azuread_administrator {
+    login_username = "s181-growingupwell-Delivery Team USR"
+    object_id      = var.service_principals.delivery_team_user_group_object_id
+  }
+  
   tags = local.tags
 }
 

--- a/terraform/modules/fhinfrastructurestack/main.tf
+++ b/terraform/modules/fhinfrastructurestack/main.tf
@@ -144,6 +144,15 @@ locals {
     "Verify",
     "WrapKey",
   ]
+  
+  # Database
+  database_connection_format = "Server=%s;Database=%s;Authentication=Active Directory Default;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+  open_referral_mock_db_connection = format(local.database_connection_format, azurerm_mssql_server.sqlserver.fully_qualified_domain_name, "${var.prefix}-fh-open-referral-mock-db")
+  idam_db_connection = format(local.database_connection_format, azurerm_mssql_server.sqlserver.fully_qualified_domain_name, "${var.prefix}-fh-idam-db")
+  referral_db_connection = format(local.database_connection_format, azurerm_mssql_server.sqlserver.fully_qualified_domain_name, "${var.prefix}-fh-referral-db")
+  service_directory_db_connection = format(local.database_connection_format, azurerm_mssql_server.sqlserver.fully_qualified_domain_name, "${var.prefix}-fh-service-directory-db")
+  notification_db_connection = format(local.database_connection_format, azurerm_mssql_server.sqlserver.fully_qualified_domain_name, "${var.prefix}-fh-notification-db")
+  report_db_connection = format(local.database_connection_format, azurerm_mssql_server.sqlserver.fully_qualified_domain_name, "${var.prefix}-fh-report-db")
 }
 
 # Create App Service Plan
@@ -228,6 +237,8 @@ resource "azurerm_windows_web_app" "fh_idam_maintenance_ui" {
     APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier"       = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix"           = "IDAM-MAINTENANCE-UI"
+    "SqlServerCache:Connection"                 = local.idam_db_connection
+    "ConnectionStrings:IdamConnection"          = local.idam_db_connection
   }
   name                                          = "${var.prefix}-as-fh-idam-maintenance-ui"
   resource_group_name                           = local.resource_group_name
@@ -282,6 +293,7 @@ resource "azurerm_windows_web_app" "fh_referral_api" {
     APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier"       = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix"           = "REFERRAL-API"
+    "ConnectionStrings:ReferralConnection"      = local.referral_db_connection
   }
   name                                          = "${var.prefix}-as-fh-referral-api"
   resource_group_name                           = local.resource_group_name
@@ -335,6 +347,8 @@ resource "azurerm_windows_web_app" "fh_referral_ui" {
     APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier"       = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix"           = "CONNECT-UI"
+    "SqlServerCache:Connection"                 = local.referral_db_connection
+    "ConnectionStrings:SharedKernelConnection"  = local.referral_db_connection
   }
   name                                          = "${var.prefix}-as-fh-referral-ui"
   resource_group_name                           = local.resource_group_name
@@ -396,6 +410,7 @@ resource "azurerm_windows_web_app" "fh_sd_api" {
     APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier"       = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix"           = "SD-API"
+    "ConnectionStrings:ServiceDirectoryConnection" = local.service_directory_db_connection
   }
   name                                          = "${var.prefix}-as-fh-sd-api"
   resource_group_name                           = local.resource_group_name
@@ -503,6 +518,7 @@ resource "azurerm_windows_web_app" "fh_sd_admin_ui" {
     APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier"       = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix"           = "MANAGE-UI"
+    "CacheConnection"                           = local.idam_db_connection
   }
   name                                          = "${var.prefix}-as-fh-sd-admin-ui"
   resource_group_name                           = local.resource_group_name
@@ -557,6 +573,7 @@ resource "azurerm_windows_web_app" "fh_referral_dashboard_ui" {
     APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier"       = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix"           = "CONNECT-DASHBOARD-UI"
+    "ConnectionStrings:SharedKernelConnection"  = local.referral_db_connection
   }
   name                                          = "${var.prefix}-as-fh-ref-dash-ui"
   resource_group_name                           = local.resource_group_name
@@ -610,6 +627,7 @@ resource "azurerm_windows_web_app" "fh_idam_api" {
     APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier"       = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix"           = "IDAM-API"
+    "ConnectionStrings:IdamConnection"          = local.idam_db_connection
   }
   name                                          = "${var.prefix}-as-fh-idam-api"
   resource_group_name                           = local.resource_group_name
@@ -663,6 +681,7 @@ resource "azurerm_windows_web_app" "fh_notification_api" {
     APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier"       = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix"           = "NOTIFICATIONS-API"
+    "ConnectionStrings:NotificationConnection"  = local.notification_db_connection
   }
   name                                          = "${var.prefix}-as-fh-notification-api"
   resource_group_name                           = local.resource_group_name
@@ -716,6 +735,7 @@ resource "azurerm_windows_web_app" "open_referral_mock_api_web_app" {
     APPLICATIONINSIGHTS_CONNECTION_STRING = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier" = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix" = "MOCK-HSDA-API"
+    "ConnectionStrings:HsdaMockResponsesConnection"  = local.open_referral_mock_db_connection
   }
   name = "${var.prefix}-as-fh-open-referral-mock-api"
   resource_group_name = local.resource_group_name
@@ -1995,15 +2015,20 @@ resource "azurerm_mssql_server_vulnerability_assessment" "sqlserver_db_vulnerabi
 
 # SQL Server Instance
 resource "azurerm_mssql_server" "sqlserver" {
-    name = "${var.prefix}-as-fh-sql-server"
-    resource_group_name = local.resource_group_name
-    location = var.location
-    version = "12.0"
+  name = "${var.prefix}-as-fh-sql-server"
+  resource_group_name = local.resource_group_name
+  location = var.location
+  version = "12.0"
 
-    administrator_login = var.sql_server_user
-    administrator_login_password = var.sql_server_pwd
+  administrator_login = var.sql_server_user
+  administrator_login_password = var.sql_server_pwd
 
-    tags = local.tags
+  azuread_administrator {
+    login_username = "s181-growingupwell-Delivery Team USR"
+    object_id      = var.service_principals.delivery_team_user_group_object_id
+  }
+  
+  tags = local.tags
 }
 
 # SQL Server Databases

--- a/terraform/modules/fhinfrastructurestack/open-referral-func.tf
+++ b/terraform/modules/fhinfrastructurestack/open-referral-func.tf
@@ -18,6 +18,7 @@ resource "azurerm_windows_function_app" "open_referral_function_app" {
     APPLICATIONINSIGHTS_CONNECTION_STRING = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier" = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix" = "OPEN-REFERRAL-FUNC"
+    "ServiceDirectoryConnection" = local.service_directory_db_connection
   }
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/FHB-831

- Enable Entra admin on each SQL server in terraform
- Fix pipeline key vault variable name
- Add connection strings via terraform for each app
- Created SQL scripts that can be found in Confluence: https://dfedigital.atlassian.net/wiki/spaces/FHGUW/pages/4934598660/SQL+Server+App+Permission+Scripts
- Populated new pipeline connection strings for GitHub in each environment ahead of time - GitHub needs more perms to execute required migrations
- Left existing secrets for connection strings in place until after merging into all environments
- EntraId now allows developers to connect with SSMS or other tools (except ADS as BYOD blocks it) so devs do not need to use username/passwords - all devs are admins still via a group - user delivery