### PR TITLE
chore(terraform): Fix annoying plan change for the open referral

### DIFF
--- a/terraform/modules/fhinfrastructurestack/open-referral-func.tf
+++ b/terraform/modules/fhinfrastructurestack/open-referral-func.tf
@@ -15,7 +15,6 @@ resource "azurerm_windows_function_app" "open_referral_function_app" {
   storage_account_name = module.open_referral_storage_account.storage_account_name
   storage_account_access_key = module.open_referral_storage_account.storage_account_primary_access_key
   app_settings = {
-    APPLICATIONINSIGHTS_CONNECTION_STRING = azurerm_application_insights.app_insights.connection_string
     "AppConfiguration:KeyVaultIdentifier" = "${var.prefix}-kv-fh-admin"
     "AppConfiguration:KeyVaultPrefix" = "OPEN-REFERRAL-FUNC"
     "ServiceDirectoryConnection" = local.service_directory_db_connection
@@ -28,6 +27,7 @@ resource "azurerm_windows_function_app" "open_referral_function_app" {
     use_32_bit_worker = false
     minimum_tls_version = "1.2"
     always_on = true
+    application_insights_connection_string = azurerm_application_insights.app_insights.connection_string
     application_stack {
       dotnet_version = var.dotnet_version_general
       use_dotnet_isolated_runtime = true


### PR DESCRIPTION
Worked out why each plan was seeing a change to the open referral function. Need to move the setting to site config in a dedicated variable now as the previous process is deprecated and was trying to merge it automatically.
