### PR TITLE
FHB-1114: Fix https redirect and GA/Clarity loading

### DIFF
--- a/src/service/mock-hsda-api/src/FamilyHubs.Mock-Hsda.Api/Program.cs
+++ b/src/service/mock-hsda-api/src/FamilyHubs.Mock-Hsda.Api/Program.cs
@@ -59,7 +59,6 @@ app.UseSwaggerUI(c =>
     c.SwaggerEndpoint("/swagger/v1/swagger.json", "HSDA Mock API V1");
 });
 
-app.UseHttpsRedirection();
 app.UseHsts();
 
 app.UseRouting();

--- a/src/service/report-api/src/FamilyHubs.Report.Api/Program.cs
+++ b/src/service/report-api/src/FamilyHubs.Report.Api/Program.cs
@@ -36,7 +36,6 @@ public class Program
         app.UseSwaggerUI();
         app.UseSerilogRequestLogging();
         app.UseMiddleware<ExceptionHandlingMiddleware>();
-        app.UseHttpsRedirection();
         app.UseHsts();
         app.UseAuthorization();
         app.MapFamilyHubsHealthChecks(typeof(Program).Assembly);

--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Security/SecurityHeaders.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Security/SecurityHeaders.cs
@@ -59,6 +59,7 @@ public static class SecurityHeaders
                         });
 
                     builder.AddScriptSrc()
+                        .UnsafeInline()
                         .StrictDynamic()
                         .WithNonce();
 

--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Security/SecurityHeaders.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Security/SecurityHeaders.cs
@@ -59,7 +59,7 @@ public static class SecurityHeaders
                         });
 
                     builder.AddScriptSrc()
-                        .UnsafeInline()
+                        .StrictDynamic()
                         .WithNonce();
 
                     builder.AddStyleSrc()

--- a/src/ui/connect-dashboard-ui/src/FamilyHubs.RequestForSupport.Web/StartupExtensions.cs
+++ b/src/ui/connect-dashboard-ui/src/FamilyHubs.RequestForSupport.Web/StartupExtensions.cs
@@ -96,8 +96,7 @@ public static class StartupExtensions
         app.UseFamilyHubsDataProtection();
 
         app.UseFamilyHubs();
-
-        app.UseHttpsRedirection();
+        
         app.UseHsts();
         app.UseStaticFiles();
 

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/StartupExtensions.cs
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/StartupExtensions.cs
@@ -139,8 +139,7 @@ public static class StartupExtensions
         app.UseFamilyHubsDataProtection();
 
         app.UseFamilyHubs();
-
-        app.UseHttpsRedirection();
+        
         app.UseHsts();
         app.UseStaticFiles();
 

--- a/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/StartupExtensions.cs
+++ b/src/ui/find-ui/src/FamilyHubs.ServiceDirectory.Web/StartupExtensions.cs
@@ -53,8 +53,7 @@ public static class StartupExtensions
         app.UseSerilogRequestLogging();
 
         app.UseFamilyHubs();
-
-        app.UseHttpsRedirection();
+        
         app.UseHsts();
         app.UseStaticFiles();
 

--- a/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.UI/StartupExtensions.cs
+++ b/src/ui/idam-maintenance-ui/src/FamilyHubs.Idams.Maintenance.UI/StartupExtensions.cs
@@ -308,8 +308,7 @@ public static class StartupExtensions
         app.UseMiddleware<CorrelationMiddleware>();
 
         app.UseFamilyHubs();
-
-        app.UseHttpsRedirection();
+        
         app.UseHsts();
         app.UseStaticFiles();
 

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/StartupExtensions.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/StartupExtensions.cs
@@ -222,8 +222,7 @@ public static class StartupExtensions
         app.UseSerilogRequestLogging();
 
         app.UseFamilyHubs();
-
-        app.UseHttpsRedirection();
+        
         app.UseHsts();
         app.UseStaticFiles();
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/FHB-1114

- Remove http redirects
- Add strict dynamic for scripts instead of unsafe inline

The above addresses odd redirect behaviour that was causing the gateway to resolve the backend over https and also allows GA/Clarity to load scripts