### PR TITLE
[FHB-856] Fix flow bugs

### DIFF
--- a/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/BaseServiceTest.cs
+++ b/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/BaseServiceTest.cs
@@ -1,0 +1,91 @@
+using System.Text;
+using System.Text.Json;
+using FamilyHubs.ServiceDirectory.Admin.Core.ApiClient;
+using FamilyHubs.ServiceDirectory.Admin.Core.Models;
+using FamilyHubs.ServiceDirectory.Admin.Core.Models.ServiceJourney;
+using FamilyHubs.ServiceDirectory.Shared.Dto;
+using FamilyHubs.ServiceDirectory.Shared.Enums;
+using FamilyHubs.ServiceDirectory.Shared.Models;
+using FamilyHubs.SharedKernel.Razor.Dashboard;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests.Services;
+
+public class BaseServiceTest : BaseTest
+{
+    private readonly IDistributedCache _cache = Substitute.For<IDistributedCache>();
+    private readonly IServiceDirectoryClient _serviceDirectoryClient = Substitute.For<IServiceDirectoryClient>();
+    private readonly ServiceModel<object> _fakeService = new()
+    {
+        Id = 1,
+        Name = "Service Name",
+        EntryPoint = ServiceDetailEntrance.FromManageServicesPage,
+        Description = "Service Summary",
+        MoreDetails = "Service Description",
+        ServiceType = ServiceTypeArg.Vcs,
+        OrganisationId = 1,
+        LaOrganisationId = 2,
+        ForChildren = true,
+        MinimumAge = 5,
+        MaximumAge = 25,
+        HasTelephone = true,
+        TelephoneNumber = "01234567890",
+        HasCost = false,
+        HasTimeDetails = false,
+        LanguageCodes = ["en"],
+        SelectedSubCategories = [20],
+        HowUse = [AttendingType.InPerson, AttendingType.Online],
+        Locations = [
+            new ServiceLocationModel(1, ["Address First Line", "Address Second Line"], "Location 1", false, "Location description")
+            {
+                HasTimeDetails = false
+            }
+        ]
+    };
+    private readonly List<OrganisationDetailsDto> _organisationDetails = [
+        new()
+        {
+            Id = 1,
+            Name = "Test Org",
+            OrganisationType = OrganisationType.VCFS,
+            Description = "Test org description",
+            AdminAreaCode = "ADM0001"
+        },
+        new ()
+        {
+            Id = 2,
+            Name = "Test LA Org",
+            OrganisationType = OrganisationType.LA,
+            Description = "Test LA org description",
+            AdminAreaCode = "ADM0002"
+        }
+    ];
+
+    public BaseServiceTest()
+    {
+        var fakeServiceBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_fakeService));
+        _cache.GetAsync(Arg.Any<string>()).Returns(fakeServiceBytes);
+
+        _serviceDirectoryClient.GetOrganisations(Arg.Any<CancellationToken>(), Arg.Any<OrganisationType?>(), Arg.Any<long?>())
+            .Returns(_organisationDetails.OfType<OrganisationDto>().ToList());
+        foreach (var organisationDto in _organisationDetails)
+        {
+            _serviceDirectoryClient.GetOrganisationById(organisationDto.Id, Arg.Any<CancellationToken>())
+                .Returns(organisationDto);
+        }
+
+        _serviceDirectoryClient.GetServiceSummaries(Arg.Any<long?>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<SortOrder>(), Arg.Any<CancellationToken>())
+            .Returns(new PaginatedList<ServiceNameDto>());
+
+        _serviceDirectoryClient.GetLocations(Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new PaginatedList<LocationDto>());
+    }
+
+    protected override void Configure(IServiceCollection services)
+    {
+        services.AddSingleton(_cache);
+        services.AddSingleton(_serviceDirectoryClient);
+    }
+}

--- a/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/BaseServiceTest.cs
+++ b/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/BaseServiceTest.cs
@@ -16,6 +16,7 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests.Services;
 public class BaseServiceTest : BaseTest
 {
     private readonly IDistributedCache _cache = Substitute.For<IDistributedCache>();
+    private readonly ITaxonomyService _taxonomyService = Substitute.For<ITaxonomyService>();
     private readonly IServiceDirectoryClient _serviceDirectoryClient = Substitute.For<IServiceDirectoryClient>();
     private readonly ServiceModel<object> _fakeService = new()
     {
@@ -35,7 +36,7 @@ public class BaseServiceTest : BaseTest
         HasCost = false,
         HasTimeDetails = false,
         LanguageCodes = ["en"],
-        SelectedSubCategories = [20],
+        SelectedSubCategories = [2],
         HowUse = [AttendingType.InPerson, AttendingType.Online],
         Locations = [
             new ServiceLocationModel(1, ["Address First Line", "Address Second Line"], "Location 1", false, "Location description")
@@ -68,6 +69,11 @@ public class BaseServiceTest : BaseTest
         var fakeServiceBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_fakeService));
         _cache.GetAsync(Arg.Any<string>()).Returns(fakeServiceBytes);
 
+        _taxonomyService.GetCategories(Arg.Any<CancellationToken>())
+            .Returns([
+                KeyValuePair.Create(new TaxonomyDto { Id = 1, Name = "Base Taxonomy" }, new List<TaxonomyDto> { new() { Id = 2, Name = "Sub Taxonomy" } })
+            ]);
+
         _serviceDirectoryClient.GetOrganisations(Arg.Any<CancellationToken>(), Arg.Any<OrganisationType?>(), Arg.Any<long?>())
             .Returns(_organisationDetails.OfType<OrganisationDto>().ToList());
         foreach (var organisationDto in _organisationDetails)
@@ -87,5 +93,6 @@ public class BaseServiceTest : BaseTest
     {
         services.AddSingleton(_cache);
         services.AddSingleton(_serviceDirectoryClient);
+        services.AddSingleton(_taxonomyService);
     }
 }

--- a/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/WhenAddingAService.cs
+++ b/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/WhenAddingAService.cs
@@ -1,17 +1,5 @@
-using System.Text;
-using System.Text.Json;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
-using FamilyHubs.ServiceDirectory.Admin.Core.ApiClient;
-using FamilyHubs.ServiceDirectory.Admin.Core.Models;
-using FamilyHubs.ServiceDirectory.Admin.Core.Models.ServiceJourney;
-using FamilyHubs.ServiceDirectory.Shared.Dto;
-using FamilyHubs.ServiceDirectory.Shared.Enums;
-using FamilyHubs.ServiceDirectory.Shared.Models;
-using FamilyHubs.SharedKernel.Razor.Dashboard;
-using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using Xunit;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests.Services;

--- a/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/WhenAddingAService.cs
+++ b/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/WhenAddingAService.cs
@@ -1,0 +1,37 @@
+using System.Text;
+using System.Text.Json;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using FamilyHubs.ServiceDirectory.Admin.Core.ApiClient;
+using FamilyHubs.ServiceDirectory.Admin.Core.Models;
+using FamilyHubs.ServiceDirectory.Admin.Core.Models.ServiceJourney;
+using FamilyHubs.ServiceDirectory.Shared.Dto;
+using FamilyHubs.ServiceDirectory.Shared.Enums;
+using FamilyHubs.ServiceDirectory.Shared.Models;
+using FamilyHubs.SharedKernel.Razor.Dashboard;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests.Services;
+
+public class WhenAddingAService : BaseServiceTest
+{
+    [Fact]
+    public async Task BackWorksCorrectly()
+    {
+        await Login(StubUser.DfeAdmin);
+
+        var page = await Navigate("manage-services/Service-Detail?flow=Add");
+
+        for (var i = 0; i < 17; i++)
+        {
+            var backLink = page.QuerySelector("a.govuk-back-link") as IHtmlAnchorElement;
+            page = await Navigate(backLink!.Href);
+        }
+
+        var heading = page.QuerySelector("h1");
+        Assert.Equal("Services", heading.GetInnerText());
+    }
+}

--- a/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/WhenEditingAService.cs
+++ b/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests/Services/WhenEditingAService.cs
@@ -1,0 +1,123 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using Xunit;
+
+namespace FamilyHubs.ServiceDirectory.Admin.Web.IntegrationTests.Services;
+
+public class WhenEditingAService : BaseServiceTest
+{
+    [Theory]
+    [MemberData(nameof(Data))]
+    public async Task BackWorksCorrectly(string rowSelector, string _)
+    {
+        await Login(StubUser.DfeAdmin);
+
+        var page = await Navigate("manage-services/Service-Detail?flow=Edit");
+        var changeLink = page.QuerySelector($"{rowSelector} a") as IHtmlAnchorElement;
+
+        var changePage = await Navigate(changeLink!.Href);
+
+        var firstBackLink = changePage.QuerySelector("a.govuk-back-link") as IHtmlAnchorElement;
+        var firstBackPage = await Navigate(firstBackLink!.Href);
+
+        var secondBackLink = firstBackPage.QuerySelector("a.govuk-back-link") as IHtmlAnchorElement;
+        var secondBackPage = await Navigate(secondBackLink!.Href);
+
+        var heading = secondBackPage.QuerySelector("h1");
+        Assert.Equal("Services", heading.GetInnerText());
+    }
+
+    [Theory]
+    [MemberData(nameof(Data))]
+    public async Task CanGoBackAfterSaving(string rowSelector, string buttonSelector)
+    {
+        await Login(StubUser.DfeAdmin);
+
+        var page = await Navigate("manage-services/Service-Detail?flow=Edit");
+        var changeLink = page.QuerySelector($"{rowSelector} a") as IHtmlAnchorElement;
+
+        var changePage = await Navigate(changeLink!.Href);
+
+        // Save!
+        var formButton = changePage.QuerySelector($"form {buttonSelector}") as IHtmlButtonElement;
+        var submitPage = await SubmitForm(formButton!);
+
+        var backLink = submitPage.QuerySelector("a.govuk-back-link") as IHtmlAnchorElement;
+        var backPage = await Navigate(backLink!.Href);
+
+        var heading = backPage.QuerySelector("h1");
+        Assert.Equal("Services", heading.GetInnerText());
+    }
+
+    [Theory]
+    [MemberData(nameof(CanFailData))]
+    public async Task CanGoBackAfterFailingThenSaving(string rowSelector, string buttonSelector)
+    {
+        await Login(StubUser.DfeAdmin);
+
+        var page = await Navigate("manage-services/Service-Detail?flow=Edit");
+        var changeLink = page.QuerySelector($"{rowSelector} a") as IHtmlAnchorElement;
+
+        var changePage = await Navigate(changeLink!.Href);
+
+        // Fail first by submitting no values
+        var formButton = changePage.QuerySelector($"form {buttonSelector}") as IHtmlButtonElement;
+        var formValues = GenerateFormValues(formButton!);
+        var failPage = await SubmitForm(formButton!.Form!.Action, formValues.Where(kv => kv.Key == "__RequestVerificationToken" || kv.Key == formButton.Name));
+
+        // Save
+        var failFormButton = failPage.QuerySelector($"form {buttonSelector}") as IHtmlButtonElement;
+        var submitPage = await SubmitForm(failFormButton!);
+
+        var backLink = submitPage.QuerySelector("a.govuk-back-link") as IHtmlAnchorElement;
+        var backPage = await Navigate(backLink!.Href);
+
+        var heading = backPage.QuerySelector("h1");
+        Assert.Equal("Services", heading.GetInnerText());
+    }
+
+    private class TestCase(string rowName, string? testId = null, bool canFail = true)
+    {
+        public readonly bool CanFail = canFail;
+
+        public string RowSelector => $"[data-testid=\"{rowName}-row\"]";
+
+        public string ButtonSelector =>
+            testId != null ? $"[data-testId=\"{testId}\"]" : "button[type=\"submit\"]";
+
+        public override string ToString() => rowName;
+    }
+
+    private static readonly IEnumerable<TestCase> RawData =
+    [
+        new("la"),
+        new("org"),
+        new("name"),
+        new("support"),
+        new("description"),
+        new("who"),
+        new("lang", "continue-button"),
+        new("cost"),
+        new("how"),
+        new("locations", "continue-button", false),
+        new("days-1", canFail: false),
+        new("extra-1"),
+        new("days", canFail: false),
+        new("extra"),
+        new("contact"),
+        new("more", canFail: false)
+    ];
+
+    public static TheoryData<string, string> Data() => FromEnumerable(RawData);
+    public static TheoryData<string, string> CanFailData() => FromEnumerable(RawData.Where(test => test.CanFail));
+
+    private static TheoryData<string, string> FromEnumerable(IEnumerable<TestCase> cases)
+    {
+        var data = new TheoryData<string, string>();
+        foreach (var testCase in cases)
+        {
+            data.Add(testCase.RowSelector, testCase.ButtonSelector);
+        }
+        return data;
+    }
+}

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Journeys/ServiceJourneyPageExtensions.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Journeys/ServiceJourneyPageExtensions.cs
@@ -16,12 +16,6 @@ public static class ServiceJourneyPageExtensions
         return page.ToString().Replace('_', '-');
     }
 
-    //todo: extend string and change to GetServicePagePath?
-    public static string GetPagePath(string slugifiedServiceJourneyPage)
-    {
-        return $"/manage-services/{slugifiedServiceJourneyPage}";
-    }
-
     public static string GetPagePath(
         this ServiceJourneyPage page,
         JourneyFlow flow,

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/LocationPageModel.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/LocationPageModel.cs
@@ -268,7 +268,7 @@ public class LocationPageModel<TInput> : HeaderPageModel, IHasErrorStatePageMode
                     return GenerateBackUrlToJourneyInitiatorPage();
                 }
 
-                return $"{ServiceJourneyPage.Select_Location.GetPagePath(ParentJourneyFlow)}&changeFlow={ParentServiceJourneyChangeFlow}";
+                return $"{ServiceJourneyPage.Select_Location.GetPagePath(ParentJourneyFlow)}&change={ParentServiceJourneyChangeFlow}";
             }
         }
 

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -380,6 +380,9 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
         if (ChangeFlow != null) queryCollection.Add("change", ChangeFlow.Value.ToUrlString());
         if (BackParam != null) queryCollection.Add("back", BackParam.Value.GetSlug());
 
+        var redo = Request.Query["redo"].ToString();
+        if (!string.IsNullOrEmpty(redo)) queryCollection.Add("redo", redo);
+
         return RedirectToSelfInternal(queryCollection, errors);
     }
 

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -191,7 +191,7 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
 
     private ServiceJourneyPage NextJourneyPage()
     {
-        if (ChangeFlow != null)
+        if (ChangeFlow is not null)
         {
             if (ChangeFlow == ServiceJourneyChangeFlow.SinglePage)
             {
@@ -280,7 +280,7 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
     {
         ServiceJourneyPage? backUrlPage = null;
 
-        if (ChangeFlow != null)
+        if (ChangeFlow is not null)
         {
             if (ChangeFlow == ServiceJourneyChangeFlow.SinglePage ||
                 (ChangeFlow == ServiceJourneyChangeFlow.LocalAuthority && CurrentPage == ServiceJourneyPage.Local_Authority))
@@ -377,8 +377,8 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
     {
         ServiceModel!.SetUserInput(userInput);
 
-        if (ChangeFlow != null) queryCollection.Add("change", ChangeFlow.Value.ToUrlString());
-        if (BackParam != null) queryCollection.Add("back", BackParam.Value.GetSlug());
+        if (ChangeFlow is not null) queryCollection.Add("change", ChangeFlow.Value.ToUrlString());
+        if (BackParam is not null) queryCollection.Add("back", BackParam.Value.GetSlug());
 
         var redo = Request.Query["redo"].ToString();
         if (!string.IsNullOrEmpty(redo)) queryCollection.Add("redo", redo);

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -143,15 +143,7 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
     public string GetServicePageUrl(
         ServiceJourneyPage page,
         ServiceJourneyChangeFlow? changeFlow = null,
-        ServiceJourneyPage? backPage = null)
-    {
-        if (backPage == null && page == ServiceJourneyPage.Service_Detail)
-        {
-            backPage = CurrentPage;
-        }
-
-        return page.GetPagePath(Flow, changeFlow ?? ChangeFlow, backPage);
-    }
+        ServiceJourneyPage? backPage = null) => page.GetPagePath(Flow, changeFlow, backPage);
 
     private ServiceJourneyPage NextPageCore()
     {
@@ -192,56 +184,46 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
     /// </exception>
     protected IActionResult NextPage(bool addBack = false)
     {
-        ServiceJourneyPage? nextPage = null;
+        var nextPageUrl = GetServicePageUrl(NextJourneyPage(), ChangeFlow, addBack ? CurrentPage : null);
+
+        return Redirect(nextPageUrl);
+    }
+
+    private ServiceJourneyPage NextJourneyPage()
+    {
         if (ChangeFlow != null)
         {
             if (ChangeFlow == ServiceJourneyChangeFlow.SinglePage)
             {
-                nextPage = ServiceJourneyPage.Service_Detail;
+                return ServiceJourneyPage.Service_Detail;
             }
-            else
+
+            var nextPage = NextPageCore();
+
+            switch (ChangeFlow)
             {
-                nextPage = NextPageCore();
-
-                if (ChangeFlow == ServiceJourneyChangeFlow.LocalAuthority &&
-                    nextPage > ServiceJourneyPage.Vcs_Organisation)
-                {
-                    nextPage = ServiceJourneyPage.Service_Detail;
-                }
-                else
-                {
-                    // if we're about to ask the user to enter the service's schedule, but we don't need one
-                    if (ChangeFlow == ServiceJourneyChangeFlow.HowUse && nextPage >= ServiceJourneyPage.Times
-                                                                      && ServiceModel!.HowUse.Length == 1 &&
-                                                                      ServiceModel.HowUse.Contains(AttendingType
-                                                                          .InPerson)
-                                                                      && ServiceModel.AllLocations.Any())
-                    {
-                        nextPage = ServiceJourneyPage.Service_Detail;
-                    }
-
-                    // if we're at the end of the location or 'how use' mini-journey
-                    if ((ChangeFlow == ServiceJourneyChangeFlow.Location && nextPage >= ServiceJourneyPage.Times)
-                        || (ChangeFlow == ServiceJourneyChangeFlow.HowUse && nextPage >= ServiceJourneyPage.Contact))
-                    {
-                        nextPage = ServiceJourneyPage.Service_Detail;
-                    }
-                }
+                // The LA change journey might include changing the VCS org too, but after that return
+                case ServiceJourneyChangeFlow.LocalAuthority when
+                    nextPage > ServiceJourneyPage.Vcs_Organisation:
+                // If we're about to ask the user to enter the service's schedule, but we don't need one
+                case ServiceJourneyChangeFlow.HowUse when
+                    nextPage >= ServiceJourneyPage.Times && ServiceModel!.HowUse.Length == 1 &&
+                    ServiceModel.HowUse.Contains(AttendingType.InPerson) && ServiceModel.AllLocations.Any():
+                // If we're at the end of the location or 'how use' mini-journey
+                case ServiceJourneyChangeFlow.Location when nextPage >= ServiceJourneyPage.Times:
+                case ServiceJourneyChangeFlow.HowUse when nextPage >= ServiceJourneyPage.Contact:
+                    return ServiceJourneyPage.Service_Detail;
+                default:
+                    return nextPage;
             }
         }
-        else if (Flow == JourneyFlow.Add)
+
+        if (Flow == JourneyFlow.Add)
         {
-            nextPage = NextPageCore();
+            return NextPageCore();
         }
 
-        if (nextPage == null)
-        {
-            throw new InvalidOperationException("Next page not set");
-        }
-
-        string nextPageUrl = GetServicePageUrl(nextPage.Value, backPage: addBack ? CurrentPage : null);
-
-        return Redirect(nextPageUrl);
+        throw new InvalidOperationException("Next page not set");
     }
 
     private ServiceJourneyPage PreviousPageAddFlow()
@@ -300,31 +282,24 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
 
         if (ChangeFlow != null)
         {
-            if (ChangeFlow == ServiceJourneyChangeFlow.SinglePage)
+            if (ChangeFlow == ServiceJourneyChangeFlow.SinglePage ||
+                (ChangeFlow == ServiceJourneyChangeFlow.LocalAuthority && CurrentPage == ServiceJourneyPage.Local_Authority))
             {
                 backUrlPage = ServiceJourneyPage.Service_Detail;
             }
             else
             {
-                if (ChangeFlow == ServiceJourneyChangeFlow.LocalAuthority
-                    && CurrentPage == ServiceJourneyPage.Local_Authority)
+                backUrlPage = PreviousPageAddFlow();
+
+                //todo: this is a bit dense. split it out a bit?
+                //todo: there's still a scenario where the user doesn't go back to the service details page
+                // when they're changing 'how use'
+                if ((ChangeFlow == ServiceJourneyChangeFlow.Location &&
+                     (CurrentPage == ServiceJourneyPage.Locations_For_Service ||
+                      backUrlPage <= ServiceJourneyPage.How_Use))
+                    || (ChangeFlow == ServiceJourneyChangeFlow.HowUse && backUrlPage < ServiceJourneyPage.How_Use))
                 {
                     backUrlPage = ServiceJourneyPage.Service_Detail;
-                }
-                else
-                {
-                    backUrlPage = PreviousPageAddFlow();
-
-                    //todo: this is a bit dense. split it out a bit?
-                    //todo: there's still a scenario where the user doesn't go back to the service details page
-                    // when they're changing 'how use'
-                    if ((ChangeFlow == ServiceJourneyChangeFlow.Location &&
-                         (CurrentPage == ServiceJourneyPage.Locations_For_Service ||
-                          backUrlPage <= ServiceJourneyPage.How_Use))
-                        || (ChangeFlow == ServiceJourneyChangeFlow.HowUse && backUrlPage < ServiceJourneyPage.How_Use))
-                    {
-                        backUrlPage = ServiceJourneyPage.Service_Detail;
-                    }
                 }
             }
         }
@@ -342,7 +317,7 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
             throw new InvalidOperationException("Back page not set");
         }
 
-        return GetServicePageUrl(backUrlPage.Value);
+        return GetServicePageUrl(backUrlPage.Value, ChangeFlow);
     }
 
     // we don't default serviceType to null even though we handle null, as the only times it should be null is when the cache has expired, which we handle here
@@ -398,28 +373,19 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
         return Task.FromResult(OnPostWithModel());
     }
 
-    //todo: or use QueryCollection?
-    //todo: version with queryCollection and userinput - when it's needed
-    protected IActionResult RedirectToSelf(IDictionary<string, StringValues> queryCollection, params ErrorId[] errors)
+    protected IActionResult RedirectToSelf(TInput userInput, IDictionary<string, StringValues> queryCollection, params ErrorId[] errors)
     {
-        ServiceModel!.SetUserInput(null!);
+        ServiceModel!.SetUserInput(userInput);
+
+        if (ChangeFlow != null) queryCollection.Add("change", ChangeFlow.Value.ToUrlString());
+        if (BackParam != null) queryCollection.Add("back", BackParam.Value.GetSlug());
 
         return RedirectToSelfInternal(queryCollection, errors);
     }
 
-    protected IActionResult RedirectToSelf(TInput userInput, params ErrorId[] errors)
-    {
-        ServiceModel!.SetUserInput(userInput);
-
-        return RedirectToSelfInternal(null, errors);
-    }
-
-    protected IActionResult RedirectToSelf(params ErrorId[] errors)
-    {
-        ServiceModel!.SetUserInput(null!);
-
-        return RedirectToSelfInternal(null, errors);
-    }
+    protected IActionResult RedirectToSelf(TInput userInput, params ErrorId[] errors) => RedirectToSelf(userInput, new Dictionary<string, StringValues>(), errors);
+    protected IActionResult RedirectToSelf(IDictionary<string, StringValues> queryCollection, params ErrorId[] errors) => RedirectToSelf(null!, queryCollection, errors);
+    protected IActionResult RedirectToSelf(params ErrorId[] errors) => RedirectToSelf((TInput) null!, errors);
 
     private IActionResult RedirectToSelfInternal(IDictionary<string, StringValues>? queryCollection, params ErrorId[] errors)
     {

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -292,8 +292,6 @@ public class ServicePageModel<TInput> : HeaderPageModel, IHasErrorStatePageModel
                 backUrlPage = PreviousPageAddFlow();
 
                 //todo: this is a bit dense. split it out a bit?
-                //todo: there's still a scenario where the user doesn't go back to the service details page
-                // when they're changing 'how use'
                 if ((ChangeFlow == ServiceJourneyChangeFlow.Location &&
                      (CurrentPage == ServiceJourneyPage.Locations_For_Service ||
                       backUrlPage <= ServiceJourneyPage.How_Use))

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml
@@ -75,7 +75,7 @@
             {
                 ++locationIndex;
                     <summary-card title="Location @locationIndex"
-                                  action1="Remove location from this service" action1-href="@(Model.GetServicePageUrl(ServiceJourneyPage.Remove_Location))&locationId=@location.Id">
+                                  action1="Remove location from this service" action1-href="@(Model.GetServicePageUrl(ServiceJourneyPage.Remove_Location, Model.ChangeFlow))&locationId=@location.Id">
                         <summary-row key="Address" class="fh-pre-wrap">@string.Join(Environment.NewLine, location.Address)</summary-row>
                         <summary-row key="Family hub">
                             @* todo: common, add to display code *@
@@ -83,11 +83,11 @@
                         </summary-row>
                         <summary-row key="Location details" class="fh-pre-wrap">@location.Description</summary-row>
                         <summary-row key="Days service is available" show-empty
-                                     action1="Change" action1-href="@(Model.GetServicePageUrl(ServiceJourneyPage.Times_At_Location))&locationId=@location.Id&redo=@redo">
+                                     action1="Change" action1-href="@(Model.GetServicePageUrl(ServiceJourneyPage.Times_At_Location, Model.ChangeFlow))&locationId=@location.Id&redo=@redo">
                             @location.Times.GetDayNames()
                         </summary-row>
                         <summary-row key="Extra availability details" show-empty class="fh-pre-wrap"
-                                     action1="Change" action1-href="@(Model.GetServicePageUrl(ServiceJourneyPage.Time_Details_At_Location))&locationId=@location.Id&redo=@redo">@(location.TimeDescription.GetDisplay())</summary-row>
+                                     action1="Change" action1-href="@(Model.GetServicePageUrl(ServiceJourneyPage.Time_Details_At_Location, Model.ChangeFlow))&locationId=@location.Id&redo=@redo">@(location.TimeDescription.GetDisplay())</summary-row>
                     </summary-card>
             }
         }

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml
@@ -93,7 +93,7 @@
         }
         <div class="govuk-button-group">
             <form method="post" novalidate>
-                <button type="submit" class="govuk-button" data-module="govuk-button"
+                <button data-testid="continue-button" type="submit" class="govuk-button" data-module="govuk-button"
                         name="@Locations_For_ServiceModel.SubmitAction" value="@Locations_For_ServiceModel.SubmitAction_Continue">
                     Continue
                 </button>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml.cs
@@ -58,7 +58,7 @@ public class Locations_For_ServiceModel : ServicePageModel
         {
             ServiceModel!.MoveCurrentLocationToLocations();
 
-            return Redirect(GetServicePageUrl(ServiceJourneyPage.Select_Location, backPage: CurrentPage));
+            return Redirect(GetServicePageUrl(ServiceJourneyPage.Select_Location, ChangeFlow, CurrentPage));
         }
         return NextPage();
     }

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Remove-Location.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Remove-Location.cshtml.cs
@@ -63,7 +63,7 @@ public class Remove_LocationModel : ServicePageModel, IRadiosPageModel
         Location = await _serviceDirectoryClient.GetLocationById(locationId, cancellationToken);
         Title = $"Do you want to remove {Location.GetDisplayName()} from this service?";
 
-        BackUrl = GetServicePageUrl(ServiceJourneyPage.Locations_For_Service);
+        BackUrl = GetServicePageUrl(ServiceJourneyPage.Locations_For_Service, ChangeFlow);
     }
 
     protected override IActionResult OnPostWithModel()
@@ -104,6 +104,6 @@ public class Remove_LocationModel : ServicePageModel, IRadiosPageModel
             }
         }
 
-        return Redirect(GetServicePageUrl(ServiceJourneyPage.Locations_For_Service));
+        return Redirect(GetServicePageUrl(ServiceJourneyPage.Locations_For_Service, ChangeFlow, BackParam));
     }
 }

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
@@ -65,13 +65,8 @@ public class Select_LocationModel : ServicePageModel, ISingleAutocompletePageMod
     /// </summary>
     protected override string GenerateBackUrl()
     {
-        // get an optional ServiceJourneyPage from the query params:
-        // passed from the service details page when in person and 0 locations
-        // passed from the 'locations at service' page
-
-        ServiceJourneyPage? backPage = BackParam ?? ServiceJourneyPage.Add_Location;
-
-        return GetServicePageUrl(backPage.Value);
+        ServiceJourneyPage backPage = Flow == JourneyFlow.Edit ? ServiceJourneyPage.Locations_For_Service : ServiceJourneyPage.Add_Location;
+        return GetServicePageUrl(backPage, ChangeFlow);
     }
 
     protected override async Task OnGetWithModelAsync(CancellationToken cancellationToken)

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -45,26 +45,26 @@
 
             @if (Model.FamilyHubsUser.Role == RoleTypes.DfeAdmin)
             {
-                <summary-row key="Local authority"
+                <summary-row data-testid="la-row" key="Local authority"
                              action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Local_Authority, ServiceJourneyChangeFlow.LocalAuthority)">
                     @Model.LaOrganisationName
                 </summary-row>
 
                 @if (service.ServiceType == ServiceTypeArg.Vcs)
                 {
-                    <summary-row key="Organisation"
+                    <summary-row data-testid="org-row" key="Organisation"
                                  action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Vcs_Organisation, ServiceJourneyChangeFlow.SinglePage)">
                         @Model.OrganisationName
                     </summary-row>
                 }
             }
 
-            <summary-row key="Name"
+            <summary-row data-testid="name-row" key="Name"
                          action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Service_Name, ServiceJourneyChangeFlow.SinglePage)">
                 @service.Name
             </summary-row>
 
-            <summary-row key="Support it offers"
+            <summary-row data-testid="support-row" key="Support it offers"
                          action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Support_Offered, ServiceJourneyChangeFlow.SinglePage)">
                 @foreach (var categoryId in service.SelectedSubCategories)
                 {
@@ -77,10 +77,10 @@
                 }
             </summary-row>
 
-            <summary-row key="Description" show-empty class="fh-pre-wrap" action1="@changeLink"
+            <summary-row data-testid="description-row" key="Description" show-empty class="fh-pre-wrap" action1="@changeLink"
                          action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Service_Description, ServiceJourneyChangeFlow.SinglePage)">@service.Description</summary-row>
 
-            <summary-row key="Does support relate to children or young people?"
+            <summary-row data-testid="who-row" key="Does support relate to children or young people?"
                          action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Who_For, ServiceJourneyChangeFlow.SinglePage)">
                 @if (service.ForChildren == false)
                 {
@@ -93,10 +93,10 @@
                 }
             </summary-row>
 
-            <summary-row key="Languages" show-empty
+            <summary-row data-testid="lang-row" key="Languages" show-empty
                          action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.What_Language, ServiceJourneyChangeFlow.SinglePage)">
                 @string.Join(", ", service.LanguageCodes!
-                    .Select(lc => ServiceDirectory.Shared.ReferenceData.Languages.CodeToName[lc])
+                    .Select(lc => ServiceDirectory.Shared.ReferenceData.Languages.CodeToName[lc.ToLower()])
                     .OrderBy(name => name))
 
                 @if (service.BritishSignLanguage == true || service.TranslationServices == true)
@@ -119,7 +119,7 @@
                 }
             </summary-row>
 
-            <summary-row key="Cost"
+            <summary-row data-testid="cost-row" key="Cost"
                          action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Service_Cost, ServiceJourneyChangeFlow.SinglePage)">
                 @if (service.HasCost == true)
                 {
@@ -135,7 +135,7 @@
         <h2 class="govuk-heading-m">Using this service</h2>
         <summary-list class="govuk-!-margin-bottom-9">
 
-            <summary-row key="How this service is provided" show-empty
+            <summary-row data-testid="how-row" key="How this service is provided" show-empty
                          action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.How_Use, ServiceJourneyChangeFlow.HowUse)">
                 @string.Join(", ", service.HowUse.Select(hu => hu.ToDescription()))
             </summary-row>
@@ -162,7 +162,7 @@
                 }
                 var redoLocationUrl = Model.ReadOnly ? "" : Model.GetServicePageUrl(locationPage!.Value, ServiceJourneyChangeFlow.Location, backPage);
 
-                <summary-row key="Locations" show-empty action1="@locationAction" action1-href="@redoLocationUrl">
+                <summary-row data-testid="locations-row" key="Locations" show-empty action1="@locationAction" action1-href="@redoLocationUrl">
                     @switch (locationsCount)
                     {
                         case 0:
@@ -199,12 +199,12 @@
 
                     <summary-row key="Location details" show-empty class="fh-pre-wrap">@location.Description.GetDisplay()</summary-row>
                     
-                    <summary-row key="Days service is available" show-empty
+                    <summary-row data-testid=@($"days-{locationNumber}-row") key="Days service is available" show-empty
                                  action1="@changeLink" action1-href="@(Model.GetServicePageUrl(ServiceJourneyPage.Times_At_Location, ServiceJourneyChangeFlow.SinglePage))&locationId=@location.Id&redo=@redo">
                         @location.Times.GetDayNames()
                     </summary-row>
                     @*todo: same data, different key to location-for-service page*@
-                    <summary-row key="Extra availability details" show-empty class="fh-pre-wrap"
+                    <summary-row data-testid=@($"extra-{locationNumber}-row") key="Extra availability details" show-empty class="fh-pre-wrap"
                                  action1="@changeLink" action1-href="@(Model.GetServicePageUrl(ServiceJourneyPage.Time_Details_At_Location, ServiceJourneyChangeFlow.SinglePage))&locationId=@location.Id&redo=@redo">@location.TimeDescription.GetDisplay()</summary-row>
 
                 </summary-list>
@@ -224,19 +224,19 @@
         {
             <h3 class="govuk-heading-m">@string.Join(", ", howUse.Select(h => h.ToDescription()))</h3>
             <summary-list class="govuk-!-margin-bottom-9">
-                <summary-row key="Days service is available" show-empty
+                <summary-row data-testid="days-row" key="Days service is available" show-empty
                              action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Times, ServiceJourneyChangeFlow.SinglePage)">
                     @service.Times.GetDayNames()
                 </summary-row>
 
-                <summary-row key="Extra availability details" show-empty class="fh-pre-wrap"
+                <summary-row data-testid="extra-row" key="Extra availability details" show-empty class="fh-pre-wrap"
                              action1="@changeLink" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Time_Details, ServiceJourneyChangeFlow.SinglePage)">@service.TimeDescription.GetDisplay()</summary-row>
             </summary-list>
         }
 
         <h2 class="govuk-heading-m">Further information</h2>
         <summary-list class="govuk-!-margin-bottom-9">
-            <summary-row key="Contact details" show-empty action1="@changeLink"
+            <summary-row data-testid="contact-row" key="Contact details" show-empty action1="@changeLink"
                          action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Contact, ServiceJourneyChangeFlow.SinglePage)">
                 @if (service.HasEmail)
                 {
@@ -257,7 +257,7 @@
 
             </summary-row>
 
-            <summary-row key="More details" show-empty class="fh-pre-wrap" action1="@changeLink"
+            <summary-row data-testid="more-row" key="More details" show-empty class="fh-pre-wrap" action1="@changeLink"
                          action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Service_More_Details, ServiceJourneyChangeFlow.SinglePage)">@service.MoreDetails.GetDisplay()</summary-row>
         </summary-list>
         

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
@@ -44,7 +44,7 @@ public class Service_DetailModel : ServicePageModel
 
     protected override string GenerateBackUrl()
     {
-        if (Flow == JourneyFlow.Edit && ChangeFlow == null)
+        if (Flow == JourneyFlow.Edit)
         {
             var serviceType = ServiceModel?.ServiceType!.Value;
 
@@ -59,12 +59,8 @@ public class Service_DetailModel : ServicePageModel
             };
         }
 
-        ServiceJourneyPage? back = BackParam;
-        if (back == null)
-        {
-            throw new InvalidOperationException("Back page not supplied as param");
-        }
-        return GetServicePageUrl(back.Value);
+        ServiceJourneyPage back = BackParam ?? ServiceJourneyPage.Service_More_Details;
+        return GetServicePageUrl(back);
     }
 
     protected override async Task OnGetWithModelAsync(CancellationToken cancellationToken)

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Time-Details-At-Location.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Time-Details-At-Location.cshtml.cs
@@ -4,6 +4,7 @@ using FamilyHubs.ServiceDirectory.Admin.Core.Models.ServiceJourney;
 using FamilyHubs.ServiceDirectory.Admin.Web.Journeys;
 using FamilyHubs.ServiceDirectory.Admin.Web.Pages.Shared;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 
@@ -51,16 +52,13 @@ public class Time_Details_At_LocationModel : ServicePageModel<TimeDetailsUserInp
 
     private ServiceLocationModel GetLocation()
     {
-        string locationIdString = Request.Query["locationId"].ToString();
-        if (locationIdString != "")
-        {
-            // user has asked to redo a specific location
-            long locationId = long.Parse(locationIdString);
+        var locationIdString = Request.Query["locationId"].ToString();
+        if (locationIdString == "") return ServiceModel!.CurrentLocation!;
 
-            return ServiceModel!.GetLocation(locationId);
-        }
+        // user has asked to redo a specific location
+        var locationId = long.Parse(locationIdString);
 
-        return ServiceModel!.CurrentLocation!;
+        return ServiceModel!.GetLocation(locationId);
     }
 
     private void SetTitle(ServiceLocationModel location)
@@ -70,19 +68,26 @@ public class Time_Details_At_LocationModel : ServicePageModel<TimeDetailsUserInp
 
     protected override IActionResult OnPostWithModel()
     {
+        var locationIdString = Request.Query["locationId"].ToString();
+        var queryCollection = new Dictionary<string, StringValues>();
+        if (locationIdString != "")
+        {
+            queryCollection.Add("locationId", locationIdString);
+        }
+
         if (!UserInput.HasDetails.HasValue)
         {
-            return RedirectToSelf(UserInput, ErrorId.Time_Details__MissingSelection);
+            return RedirectToSelf(UserInput, queryCollection, ErrorId.Time_Details__MissingSelection);
         }
 
         if (UserInput.HasDetails == true && string.IsNullOrWhiteSpace(UserInput.Description))
         {
-            return RedirectToSelf(UserInput, ErrorId.Time_Details_At_Location__MissingText);
+            return RedirectToSelf(UserInput, queryCollection, ErrorId.Time_Details_At_Location__MissingText);
         }
 
         if (UserInput.HasDetails == true && !string.IsNullOrWhiteSpace(UserInput.Description) && UserInput.Description.Replace("\r", "").Length > MaxLength)
         {
-            return RedirectToSelf(UserInput, ErrorId.Time_Details_At_Location__DescriptionTooLong);
+            return RedirectToSelf(UserInput, queryCollection, ErrorId.Time_Details_At_Location__DescriptionTooLong);
         }
 
         var location = GetLocation();
@@ -100,7 +105,7 @@ public class Time_Details_At_LocationModel : ServicePageModel<TimeDetailsUserInp
             location.TimeDescription = null;
         }
 
-        string redo = Request.Query["redo"].ToString();
+        var redo = Request.Query["redo"].ToString();
         if (redo != "")
         {
             return Redirect(GetServicePageUrl(ServiceJourneyPageExtensions.FromSlug(redo)));

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Time-Details-At-Location.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Time-Details-At-Location.cshtml.cs
@@ -30,12 +30,6 @@ public class Time_Details_At_LocationModel : ServicePageModel<TimeDetailsUserInp
 
     protected override void OnGetWithModel()
     {
-        string redo = Request.Query["redo"].ToString();
-        if (redo != "")
-        {
-            BackUrl = $"{ServiceJourneyPageExtensions.GetPagePath(redo)}?flow={Flow}";
-        }
-
         var location = GetLocation();
         SetTitle(location);
 
@@ -64,6 +58,12 @@ public class Time_Details_At_LocationModel : ServicePageModel<TimeDetailsUserInp
     private void SetTitle(ServiceLocationModel location)
     {
         Title = $"Can you provide more details about using this service at {location.DisplayName}?";
+
+        var redo = Request.Query["redo"].ToString();
+        if (!string.IsNullOrEmpty(redo))
+        {
+            BackUrl = GetServicePageUrl(ServiceJourneyPageExtensions.FromSlug(redo), ChangeFlow);
+        }
     }
 
     protected override IActionResult OnPostWithModel()
@@ -108,7 +108,7 @@ public class Time_Details_At_LocationModel : ServicePageModel<TimeDetailsUserInp
         var redo = Request.Query["redo"].ToString();
         if (redo != "")
         {
-            return Redirect(GetServicePageUrl(ServiceJourneyPageExtensions.FromSlug(redo)));
+            return Redirect(GetServicePageUrl(ServiceJourneyPageExtensions.FromSlug(redo), ChangeFlow));
         }
 
         return NextPage();

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/What-Language.cshtml
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/What-Language.cshtml
@@ -87,7 +87,7 @@
                         </div>
                     </fieldset>
                 </div>
-                <button class="govuk-button" data-module="govuk-button">Continue</button>
+                <button data-testid="continue-button" class="govuk-button" data-module="govuk-button">Continue</button>
             </form>
         </div>
     </div>

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/times-at-location.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/times-at-location.cshtml.cs
@@ -35,16 +35,6 @@ public class times_at_locationModel : ServicePageModel, ICheckboxesPageModel
 
     protected override void OnGetWithModel()
     {
-        //todo: redo mode will take user back to locations at service page
-        //todo: how does redo work from details page?
-        //todo: look for location id in url, if not there, work on current location
-
-        string redo = Request.Query["redo"].ToString();
-        if (redo != "")
-        {
-            BackUrl = $"{ServiceJourneyPageExtensions.GetPagePath(redo)}?flow={Flow}";
-        }
-
         var location = GetLocation();
 
         SetTitle(location);
@@ -69,6 +59,12 @@ public class times_at_locationModel : ServicePageModel, ICheckboxesPageModel
     private void SetTitle(ServiceLocationModel location)
     {
         Title = $"On which days can people use this service at {location.DisplayName}?";
+
+        var redo = Request.Query["redo"].ToString();
+        if (!string.IsNullOrEmpty(redo))
+        {
+            BackUrl = GetServicePageUrl(ServiceJourneyPageExtensions.FromSlug(redo), ChangeFlow);
+        }
     }
 
     protected override IActionResult OnPostWithModel()
@@ -82,7 +78,7 @@ public class times_at_locationModel : ServicePageModel, ICheckboxesPageModel
         string redo = Request.Query["redo"].ToString();
         if (redo != "")
         {
-            return Redirect(GetServicePageUrl(ServiceJourneyPageExtensions.FromSlug(redo)));
+            return Redirect(GetServicePageUrl(ServiceJourneyPageExtensions.FromSlug(redo), ChangeFlow));
         }
 
         return NextPage();


### PR DESCRIPTION
Fixes the issue from the ticket where the persisted change value causes the back button to loop into the edit flow again rather than back out to the service list.

Also fixed the same loop occurring when saving instead of clicking back out of a change.

ALSO fixed another issue where triggering a validation error within a change flow would cause the app to lose track of where you are.

ALSO ALSO fixed another issue where triggering a validation error on "Extra availability details" would just return "Sorry, there is a problem with the service"

Finally fixed going back from manage location pages to manage service pages. (ie Manage service > Add or remove locations > Add location > Add new location > Back > Back > ERROR)

----

Plus some refactoring to make the next page code very slightly easier to parse but it's still a mess.
And some data-testids to make the tests I wrote to make sure all the pages worked (there may be a couple gaps for multi-page flows)
