### PR TITLE
ci(playwright): Performance Optimisation

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -112,7 +112,7 @@ jobs:
           
       - name: Run Playwright Test Suite
         shell: bash
-        run: npx playwright test
+        run: npx playwright test --workers `nproc`
         
       - name: Upload Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Noticed the Playwright test uses half the number of cores on the CPU by default when parallelising its tests. This is usually to make sure there are free resources left for other things the user may want to be doing with their system.

However in our case the entire purpose of the runner is to run these tests, so we can speed it up (mainly Manage atm but this will scale better as more and more tests are added to both UIs) by telling it to use all of the cores of the runner (`nproc` is a Linux command that returns the number of CPU cores)

With Optimisation (2m 56s):
<img width="1595" alt="Screenshot 2025-01-14 at 11 13 43 AM" src="https://github.com/user-attachments/assets/62cb8bec-8c9c-4c46-bd63-01a7556debae" />


Without Optimisation (6m 8s):
<img width="1557" alt="Screenshot 2025-01-14 at 11 14 11 AM" src="https://github.com/user-attachments/assets/3eb09d16-6932-4f92-b248-e7e621e9e8f2" />