### PR TITLE
FHB-1238 - deds schema update

### DIFF
--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20250114141038_updateDedsSchema.Designer.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20250114141038_updateDedsSchema.Designer.cs
@@ -4,6 +4,7 @@ using FamilyHubs.ServiceDirectory.Data.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
@@ -12,9 +13,11 @@ using NetTopologySuite.Geometries;
 namespace FamilyHubs.ServiceDirectory.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250114141038_updateDedsSchema")]
+    partial class updateDedsSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20250114141038_updateDedsSchema.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20250114141038_updateDedsSchema.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FamilyHubs.ServiceDirectory.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class updateDedsSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<byte>(
+                name: "MinimumAge",
+                schema: "deds",
+                table: "Services",
+                type: "tinyint",
+                nullable: true,
+                oldClrType: typeof(byte),
+                oldType: "tinyint");
+
+            migrationBuilder.AlterColumn<byte>(
+                name: "MaximumAge",
+                schema: "deds",
+                table: "Services",
+                type: "tinyint",
+                nullable: true,
+                oldClrType: typeof(byte),
+                oldType: "tinyint");
+
+            migrationBuilder.AlterColumn<short>(
+                name: "YearIncorporated",
+                schema: "deds",
+                table: "Organizations",
+                type: "smallint",
+                nullable: true,
+                oldClrType: typeof(short),
+                oldType: "smallint");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LegalStatus",
+                schema: "deds",
+                table: "Organizations",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<byte>(
+                name: "MinimumAge",
+                schema: "deds",
+                table: "Services",
+                type: "tinyint",
+                nullable: false,
+                defaultValue: (byte)0,
+                oldClrType: typeof(byte),
+                oldType: "tinyint",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte>(
+                name: "MaximumAge",
+                schema: "deds",
+                table: "Services",
+                type: "tinyint",
+                nullable: false,
+                defaultValue: (byte)0,
+                oldClrType: typeof(byte),
+                oldType: "tinyint",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<short>(
+                name: "YearIncorporated",
+                schema: "deds",
+                table: "Organizations",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (short)0,
+                oldClrType: typeof(short),
+                oldType: "smallint",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LegalStatus",
+                schema: "deds",
+                table: "Organizations",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Converters/StringToNullableTypeConverter.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Converters/StringToNullableTypeConverter.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FamilyHubs.SharedKernel.OpenReferral.Converters;
+
+/// <summary>
+/// Converts a JSON string value into a nullable type.
+/// </summary>
+public class StringToNullableTypeConverter : JsonConverter<object?>
+{
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return true;
+    }
+
+    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var stringValue = reader.GetString();
+            if (string.IsNullOrEmpty(stringValue))
+            {
+                return null;
+            }
+
+            var targetType = Nullable.GetUnderlyingType(typeToConvert) ?? typeToConvert;
+            if (targetType == typeof(Guid))
+            {
+                return Convert.ChangeType(Guid.Parse(stringValue), targetType);
+            }
+            if(targetType == typeof(DateTime))
+            {
+                return Convert.ChangeType(DateTime.Parse(stringValue, CultureInfo.CurrentCulture), targetType);
+            }
+
+            if (targetType == typeof(TimeSpan))
+            {
+                return Convert.ChangeType(TimeSpan.Parse(stringValue, CultureInfo.CurrentCulture), targetType);
+            }
+            return Convert.ChangeType(stringValue, targetType);
+        }
+
+        return JsonSerializer.Deserialize(ref reader, typeToConvert, options);
+    }
+
+    public override void Write(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
+    {
+        if (value is not null)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/CostOption.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/CostOption.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using FamilyHubs.SharedKernel.OpenReferral.Converters;
 
 namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
 
@@ -8,9 +9,11 @@ public class CostOption : BaseHsdsEntity
     public Guid ServiceId { get; init; }
 
     [JsonPropertyName("valid_from")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public DateTime? ValidFrom { get; init; } // TODO: .NET 8 supports native DateOnly, so convert.
 
     [JsonPropertyName("valid_to")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public DateTime? ValidTo { get; init; } // TODO: .NET 8 supports native DateOnly, so convert.
 
     [JsonPropertyName("option")]
@@ -20,6 +23,7 @@ public class CostOption : BaseHsdsEntity
     public string? Currency { get; init; }
 
     [JsonPropertyName("amount")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public decimal? Amount { get; init; }
 
     [JsonPropertyName("amount_description")]

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Location.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Location.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using FamilyHubs.SharedKernel.OpenReferral.Converters;
 
 namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
 
@@ -26,9 +27,11 @@ public class Location : BaseHsdsEntity
     public string? Transportation { get; init; }
 
     [JsonPropertyName("latitude")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public decimal? Latitude { get; init; }
 
     [JsonPropertyName("longitude")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public decimal? Longitude { get; init; }
 
     [JsonPropertyName("external_identifier")]

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Organization.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Organization.cs
@@ -20,10 +20,10 @@ public class Organization : BaseHsdsEntity
     public string? Website { get; init; }
 
     [JsonPropertyName("year_incorporated")]
-    public required short YearIncorporated { get; init; }
+    public short? YearIncorporated { get; init; }
 
     [JsonPropertyName("legal_status")]
-    public required string LegalStatus { get; init; }
+    public string? LegalStatus { get; init; }
 
     [JsonPropertyName("logo")]
     public string? Logo { get; init; }

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Organization.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Organization.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using FamilyHubs.SharedKernel.OpenReferral.Converters;
 
 namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
 
@@ -20,6 +21,7 @@ public class Organization : BaseHsdsEntity
     public string? Website { get; init; }
 
     [JsonPropertyName("year_incorporated")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public short? YearIncorporated { get; init; }
 
     [JsonPropertyName("legal_status")]
@@ -32,6 +34,7 @@ public class Organization : BaseHsdsEntity
     public string? Uri { get; init; }
 
     [JsonPropertyName("parent_organization_id")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public Guid? ParentOrganizationId { get; init; }
 
     [JsonPropertyName("funding")]

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Phone.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Phone.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using FamilyHubs.SharedKernel.OpenReferral.Converters;
 
 namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
 
@@ -23,6 +24,7 @@ public class Phone : BaseHsdsEntity
     public required string Number { get; init; }
 
     [JsonPropertyName("extension")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public short? Extension { get; init; }
 
     [JsonPropertyName("type")]

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Schedule.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Schedule.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using FamilyHubs.SharedKernel.OpenReferral.Converters;
 
 namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
 
@@ -14,21 +15,27 @@ public class Schedule : BaseHsdsEntity
     public Guid? ServiceAtLocationId { get; init; }
 
     [JsonPropertyName("valid_from")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public DateTime? ValidFrom { get; init; }
 
     [JsonPropertyName("valid_to")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public DateTime? ValidTo { get; init; }
 
     [JsonPropertyName("dtstart")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public DateTime? DtStart { get; init; }
 
     [JsonPropertyName("timezone")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public byte? Timezone { get; init; }
 
     [JsonPropertyName("until")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public DateTime? Until { get; init; }
 
     [JsonPropertyName("count")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public short? Count { get; init; }
 
     [JsonPropertyName("wkst")]
@@ -38,6 +45,7 @@ public class Schedule : BaseHsdsEntity
     public string? Freq { get; init; }
 
     [JsonPropertyName("interval")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public short? Interval { get; init; }
 
     [JsonPropertyName("byday")]
@@ -56,9 +64,11 @@ public class Schedule : BaseHsdsEntity
     public string? Description { get; init; }
 
     [JsonPropertyName("opens_at")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public TimeSpan? OpensAt { get; init; } // TODO: // TODO: .NET 8 supports native TimeOnly, so convert.
 
     [JsonPropertyName("closes_at")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public TimeSpan? ClosesAt { get; init; } // TODO: .NET 8 supports native TimeOnly, so convert.
 
     [JsonPropertyName("schedule_link")]

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Service.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Service.cs
@@ -48,10 +48,10 @@ public class Service : BaseHsdsEntity
     public string? EligibilityDescription { get; init; }
 
     [JsonPropertyName("minimum_age")]
-    public byte MinimumAge { get; init; }
+    public byte? MinimumAge { get; init; }
 
     [JsonPropertyName("maximum_age")]
-    public byte MaximumAge { get; init; }
+    public byte? MaximumAge { get; init; }
 
     [JsonPropertyName("assured_date")]
     public DateTime? AssuredDate { get; init; }

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Service.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/Service.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using FamilyHubs.SharedKernel.OpenReferral.Converters;
 
 namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
 
@@ -54,6 +55,7 @@ public class Service : BaseHsdsEntity
     public byte? MaximumAge { get; init; }
 
     [JsonPropertyName("assured_date")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public DateTime? AssuredDate { get; init; }
 
     [JsonPropertyName("assurer_email")]

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/TaxonomyTerm.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/OpenReferral/Entities/TaxonomyTerm.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using FamilyHubs.SharedKernel.OpenReferral.Converters;
 
 namespace FamilyHubs.SharedKernel.OpenReferral.Entities;
 
@@ -14,6 +15,7 @@ public class TaxonomyTerm : BaseHsdsEntity
     public required string Description { get; init; }
 
     [JsonPropertyName("parent_id")]
+    [JsonConverter(typeof(StringToNullableTypeConverter))]
     public Guid? ParentId { get; init; }
 
     [JsonPropertyName("taxonomy")]

--- a/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/OpenReferral/Converters/WhenUsingStringToNullableTypeConverter.cs
+++ b/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/OpenReferral/Converters/WhenUsingStringToNullableTypeConverter.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FamilyHubs.SharedKernel.OpenReferral.Converters;
+
+namespace FamilyHubs.SharedKernel.UnitTests.OpenReferral.Converters;
+
+public class WhenUsingStringToNullableTypeConverter
+{
+    
+    [Fact]
+    public void ShouldReturnGuid_WhenGuidIsAStringInJson()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        var jsonData = $"{{\"id\": \"{guid}\"}}";
+
+        // Act
+        var result = JsonSerializer.Deserialize<MyMockData>(jsonData);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(guid, result.Id);
+    }
+    
+    [Fact]
+    public void ShouldReturnNull_WhenGuidIsAEmptyStringInJson()
+    {
+        // Arrange
+        var jsonData = "{\"id\": \"\"}";
+
+        // Act
+        var result = JsonSerializer.Deserialize<MyMockData>(jsonData);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Null(result.Id);
+    }
+    
+    [Fact]
+    public void ShouldReturnDateTime_WhenStringHasADateTime()
+    {
+        // Arrange
+        var jsonData = $"{{\"date\": \"2024-11-14T16:53:16.997\"}}";
+
+        // Act
+        var result = JsonSerializer.Deserialize<MyMockData>(jsonData);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Date);
+        var expectedDate = "2024-11-14";
+        var resultDate = $"{result.Date.Value.Year}-{result.Date.Value.Month}-{result.Date.Value.Day}";
+        Assert.Equal(expectedDate, resultDate);
+    }
+    
+    [Fact]
+    public void ShouldReturnNull_WhenStringHasNoDateTime()
+    {
+        // Arrange
+        var jsonData = $"{{\"date\": \"\"}}";
+
+        // Act
+        var result = JsonSerializer.Deserialize<MyMockData>(jsonData);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Null(result.Date);
+    }
+    
+    
+    private class MyMockData
+    {
+        [JsonPropertyName("id")]
+        [JsonConverter(typeof(StringToNullableTypeConverter))]
+        public Guid? Id { get; init; }
+        
+        [JsonPropertyName("date")]
+        [JsonConverter(typeof(StringToNullableTypeConverter))]
+        public DateTime? Date { get; init; }
+        
+        [JsonPropertyName("time")]
+        public TimeSpan? Time { get; init; }
+    }
+    
+    
+}


### PR DESCRIPTION
Fix a couple of issues with the deds schema. With the updates we can ingest international v3

- Update schema to account for some nullable fields to match international schema. The fields are also not in our MVD. This includes a database migration from entitiy framework.
- Added a custom JSON deserlalizer to handle empty strings in the JSON. This is because the schema uses strings for all except numbers.
