### PR TITLE
chore: Set organisation created date as not nullable

### DIFF
--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Config/OrganisationConfiguration.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Config/OrganisationConfiguration.cs
@@ -46,5 +46,8 @@ public class OrganisationConfiguration : EntityBaseConfiguration<Organisation>
             .HasForeignKey(l => l.OrganisationId)
             .IsRequired(false)
             .OnDelete(DeleteBehavior.Restrict);
+        
+        builder.Property(t => t.Created)
+            .IsRequired();
     }
 }

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20250117130759_SetOrganisationCreatedNotNull.Designer.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20250117130759_SetOrganisationCreatedNotNull.Designer.cs
@@ -4,6 +4,7 @@ using FamilyHubs.ServiceDirectory.Data.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
@@ -12,9 +13,11 @@ using NetTopologySuite.Geometries;
 namespace FamilyHubs.ServiceDirectory.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250117130759_SetOrganisationCreatedNotNull")]
+    partial class SetOrganisationCreatedNotNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20250117130759_SetOrganisationCreatedNotNull.cs
+++ b/src/service/service-directory-api/src/FamilyHubs.ServiceDirectory.Data/Migrations/20250117130759_SetOrganisationCreatedNotNull.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FamilyHubs.ServiceDirectory.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SetOrganisationCreatedNotNull : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "Organisations",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "Organisations",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+        }
+    }
+}


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/FHB-1237

Set the Organisation table Created column as not nullable as it will cause issues with the ADF given that the staging table does not allow nulls for the same column.