### PR TITLE
ci: Fix Package Cache

### DIFF
--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -36,8 +36,7 @@ jobs:
         shell: bash
         run: dotnet tool install --global LiquidTestReports.Cli --version 2.0.0-beta.2
 
-      - name: Package Cache
-        id: cache
+      - name: NuGet Package Cache
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-NuGet-${{ hashFiles('./*.csproj') }}
+          key: ${{ runner.os }}-NuGet-${{ hashFiles('./**.csproj') }}
           restore-keys: |
-            ${{ runner.os }}-NuGet-${{ hashFiles('./*.csproj') }}
+            ${{ runner.os }}-NuGet-${{ hashFiles('./**.csproj') }}
 
       - name: Install & Configure Spatialite
         if: ${{ inputs.working_directory == 'service/service-directory-api' || inputs.working_directory == 'service/referral-api' }}

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-NuGet-${{ hashFiles('./**.csproj') }}
           restore-keys: |
-            ${{ runner.os }}-nuget-
+            ${{ runner.os }}-NuGet-${{ hashFiles('./**.csproj') }}
 
       - name: Install & Configure Spatialite
         if: ${{ inputs.working_directory == 'service/service-directory-api' || inputs.working_directory == 'service/referral-api' }}

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-NuGet-${{ hashFiles('./**.csproj') }}
+          key: ${{ runner.os }}-NuGet-${{ hashFiles('inputs.working_directory/**.csproj') }}
           restore-keys: |
-            ${{ runner.os }}-NuGet-${{ hashFiles('./**.csproj') }}
+            ${{ runner.os }}-NuGet-${{ hashFiles('inputs.working_directory/**.csproj') }}
 
       - name: Install & Configure Spatialite
         if: ${{ inputs.working_directory == 'service/service-directory-api' || inputs.working_directory == 'service/referral-api' }}

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build_and_test:
     name: Build Project & Run Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: src/${{ inputs.working_directory }}

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-NuGet-${{ hashFiles('./**.csproj') }}
+          key: ${{ runner.os }}-NuGet-${{ hashFiles('./*.csproj') }}
           restore-keys: |
-            ${{ runner.os }}-NuGet-${{ hashFiles('./**.csproj') }}
+            ${{ runner.os }}-NuGet-${{ hashFiles('./*.csproj') }}
 
       - name: Install & Configure Spatialite
         if: ${{ inputs.working_directory == 'service/service-directory-api' || inputs.working_directory == 'service/referral-api' }}

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-NuGet-${{ hashFiles('inputs.working_directory/**.csproj') }}
+          key: ${{ runner.os }}-NuGet-${{ inputs.job_name }}-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
-            ${{ runner.os }}-NuGet-${{ hashFiles('inputs.working_directory/**.csproj') }}
+            ${{ runner.os }}-NuGet-${{ inputs.job_name }}-${{ hashFiles('**/*.csproj') }}
 
       - name: Install & Configure Spatialite
         if: ${{ inputs.working_directory == 'service/service-directory-api' || inputs.working_directory == 'service/referral-api' }}

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
         run: dotnet tool install --global LiquidTestReports.Cli --version 2.0.0-beta.2
 
-      - name: Package Cache
+      - name: Package Cachee
         id: cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
         run: dotnet tool install --global LiquidTestReports.Cli --version 2.0.0-beta.2
 
-      - name: Package Cachee
+      - name: Package Cache
         id: cache
         uses: actions/cache@v4
         with:
@@ -45,7 +45,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-NuGet-${{ inputs.job_name }}-${{ hashFiles('**/*.csproj') }}
 
-      - name: Install & Configure Spatialite
+      - name: Install & Configure SpatiaLite
         if: ${{ inputs.working_directory == 'service/service-directory-api' || inputs.working_directory == 'service/referral-api' }}
         shell: bash
         run: |
@@ -54,7 +54,6 @@ jobs:
           sudo ldconfig "/usr/lib/x86_64-linux-gnu/mod_spatialite.so"
 
       - name: Restore Project
-        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: dotnet restore
 

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -37,6 +37,7 @@ jobs:
         run: dotnet tool install --global LiquidTestReports.Cli --version 2.0.0-beta.2
 
       - name: Package Cache
+        id: cache
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
@@ -53,6 +54,7 @@ jobs:
           sudo ldconfig "/usr/lib/x86_64-linux-gnu/mod_spatialite.so"
 
       - name: Restore Project
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: dotnet restore
 

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build_and_test:
     name: Build Project & Run Tests
-    runs-on: 'ubuntu-22.04'
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: src/${{ inputs.working_directory }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build_and_test:
-    name: ${{ matrix.job_name }}
+    name: Test - ${{ matrix.job_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,37 +40,37 @@ jobs:
           ]
         include:
           - working_directory: service/notification-api
-            job_name: "Test - Notification API"
+            job_name: "Notification API"
           - working_directory: service/idam-api
-            job_name: "Test - IDAM API"
+            job_name: "IDAM API"
           - working_directory: service/service-directory-api
-            job_name: "Test - Service Directory API"
+            job_name: "Service Directory API"
           - working_directory: service/referral-api
-            job_name: "Test - Referral API"
+            job_name: "Referral API"
           - working_directory: service/report-api
-            job_name: "Test - Report API"
+            job_name: "Report API"
           - working_directory: service/mock-hsda-api
-            job_name: "Test - Mock HSDA API"
+            job_name: "Mock HSDA API"
           - working_directory: function/open-referral-function
-            job_name: "Test - Open Referral Function"
+            job_name: "Open Referral Function"
           - working_directory: ui/connect-dashboard-ui
-            job_name: "Test - Connect Dashboard UI"
+            job_name: "Connect Dashboard UI"
           - working_directory: ui/connect-ui
-            job_name: "Test - Connect UI"
+            job_name: "Connect UI"
           - working_directory: ui/find-ui
-            job_name: "Test - Find UI"
+            job_name: "Find UI"
           - working_directory: ui/idam-maintenance-ui
-            job_name: "Test - IDAM Maintenance UI"
+            job_name: "IDAM Maintenance UI"
           - working_directory: ui/manage-ui
-            job_name: "Test - Manage UI"
+            job_name: "Manage UI"
           - working_directory: shared/referral-shared
-            job_name: "Test - Referral Shared"
+            job_name: "Referral Shared"
           - working_directory: shared/service-directory-shared
-            job_name: "Test - Service Directory Shared"
+            job_name: "Service Directory Shared"
           - working_directory: shared/shared-kernel
-            job_name: "Test - Kernel Shared"
+            job_name: "Kernel Shared"
           - working_directory: shared/web-components
-            job_name: "Test - Web Components Shared"
+            job_name: "Web Components Shared"
     uses: ./.github/workflows/build-and-test-template.yml
     with:
       working_directory: ${{ matrix.working_directory }}

--- a/.github/workflows/build-upload-artifact.yml
+++ b/.github/workflows/build-upload-artifact.yml
@@ -17,6 +17,9 @@ on:
         required: false
         default: 'ubuntu-22.04'
         type: string
+      job_name:
+        required: true
+        type: string
 
 jobs:
   build-project-upload-artifact:
@@ -38,13 +41,13 @@ jobs:
         with:
           dotnet-version: ${{ vars.DOTNET_VERSION_V8 }}
 
-      - name: Package Cache
+      - name: NuGet Package Cache
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-NuGet-${{ inputs.job_name }}-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
-            ${{ runner.os }}-nuget-
+            ${{ runner.os }}-NuGet-${{ inputs.job_name }}-${{ hashFiles('**/*.csproj') }}
 
       - name: Restore Project
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build-projects-upload-artifacts:
-    name: ${{ matrix.job_name }}
+    name: Build - ${{ matrix.job_name }}
     strategy:
       fail-fast: true
       matrix:
@@ -45,47 +45,48 @@ jobs:
         include:
           - project: src/service/idam-api/
             publish_project: FamilyHubs.Idam.Api
-            job_name: Build - IDAM API
+            job_name: IDAM API
           - project: src/service/notification-api/
             publish_project: FamilyHubs.Notification.Api
-            job_name: Build - Notification API
+            job_name: Notification API
           - project: src/service/referral-api/
             publish_project: FamilyHubs.Referral.Api
-            job_name: Build - Referral API
+            job_name: Referral API
           - project: src/service/report-api/
             publish_project: FamilyHubs.Report.Api
-            job_name: Build - Report API
+            job_name: Report API
           - project: src/service/service-directory-api/
             publish_project: FamilyHubs.ServiceDirectory.Api
-            job_name: Build - Service Directory API
+            job_name: Service Directory API
           - project: src/service/mock-hsda-api/
             publish_project: FamilyHubs.Mock-Hsda.Api
-            job_name: Build - Mock HSDA API
+            job_name: Mock HSDA API
             dotnet_version_override: "8.0.x"
           - project: src/function/open-referral-function/
             publish_project: FamilyHubs.OpenReferral.Function
-            job_name: Build - Open Referral Function
+            job_name: Open Referral Function
             dotnet_version_override: "8.0.x"
           - project: src/ui/connect-dashboard-ui/
             publish_project: FamilyHubs.RequestForSupport.Web
-            job_name: Build - Connect Dashboard UI
+            job_name: Connect Dashboard UI
           - project: src/ui/connect-ui/
             publish_project: FamilyHubs.Referral.Web
-            job_name: Build - Connect UI
+            job_name: Connect UI
           - project: src/ui/find-ui/
             publish_project: FamilyHubs.ServiceDirectory.Web
-            job_name: Build - Find UI
+            job_name: Find UI
           - project: src/ui/idam-maintenance-ui/
             publish_project: FamilyHubs.Idams.Maintenance.UI
-            job_name: Build - IDAM Maintenance UI
+            job_name: IDAM Maintenance UI
           - project: src/ui/manage-ui/
             publish_project: FamilyHubs.ServiceDirectory.Admin.Web
-            job_name: Build - Manage UI
+            job_name: Manage UI
     uses: ./.github/workflows/build-upload-artifact.yml
     with:
       project: ${{ matrix.project }}
       publish_project: ${{ matrix.publish_project }}
       dotnet_version: ${{ matrix.dotnet_version_override || vars.DOTNET_VERSION }}
+      job_name: ${{ matrix.job_name }}
     
   deploy-api-services:
     name: ${{ matrix.job_name }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: dotnet tool install --global LiquidTestReports.Cli --version 2.0.0-beta.2
 
-      - name: Install & Configure Spatialite
+      - name: Install & Configure SpatiaLite
         shell: bash
         run: |
           sudo apt-get update

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-NuGet-SuperSolution-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
-            ${{ runner.os }}-nuget-
+            ${{ runner.os }}-NuGet-SuperSolution-${{ hashFiles('**/*.csproj') }}
 
       - name: Setup .NET ${{ vars.DOTNET_VERSION_V8 }}
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
Noticed the package cache for NuGet hasn't been working the whole time. The cache isn't thread safe, so when multiple runners (e.g., PR build & test, or building artifacts before deploying) are using it, none of them can properly write to it and quickly break, which means that most of them were just grabbing their packages from NuGet instead of the cache and not being sped up.

Unfortunately the `hashFiles()` function only works relative to the root of the repository so you can't hash files specific to a project easily. As such the workaround is to add the name of the project into the cache to give each project its own cache.

Since the SonarCloud runs from the SuperSolution it also has its own special cache key.

Also technically it's SpatiaLite and not Spatialite so I just corrected that too while I'm there :P