### PR TITLE
FHB-1278: Fix E2E tests

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -97,8 +97,8 @@ jobs:
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         shell: bash
-        run: npx playwright install
-          
+        run: npx playwright install --no-shell      
+      
       - name: Create Environment Variables
         shell: bash
         run: |

--- a/test/find-e2e-tests/package-lock.json
+++ b/test/find-e2e-tests/package-lock.json
@@ -9,18 +9,18 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.0.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.48.1",
-        "@serenity-js/assertions": "^3.29.4",
-        "@serenity-js/console-reporter": "^3.29.4",
-        "@serenity-js/core": "^3.29.4",
-        "@serenity-js/playwright": "^3.29.4",
-        "@serenity-js/playwright-test": "^3.29.4",
-        "@serenity-js/serenity-bdd": "^3.29.4",
-        "@serenity-js/web": "^3.29.4",
-        "@types/node": "^22.8.0"
+        "@playwright/test": "^1.0.0",
+        "@serenity-js/assertions": "^3.0.0",
+        "@serenity-js/console-reporter": "^3.0.0",
+        "@serenity-js/core": "^3.0.0",
+        "@serenity-js/playwright": "^3.0.0",
+        "@serenity-js/playwright-test": "^3.0.0",
+        "@serenity-js/serenity-bdd": "^3.0.0",
+        "@serenity-js/web": "^3.0.0",
+        "@types/node": "^22.0.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/test/find-e2e-tests/package.json
+++ b/test/find-e2e-tests/package.json
@@ -10,17 +10,17 @@
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "^1.48.1",
-    "@serenity-js/assertions": "^3.29.4",
-    "@serenity-js/console-reporter": "^3.29.4",
-    "@serenity-js/core": "^3.29.4",
-    "@serenity-js/playwright": "^3.29.4",
-    "@serenity-js/playwright-test": "^3.29.4",
-    "@serenity-js/serenity-bdd": "^3.29.4",
-    "@serenity-js/web": "^3.29.4",
-    "@types/node": "^22.8.0"
+    "@playwright/test": "^1.0.0",
+    "@serenity-js/assertions": "^3.0.0",
+    "@serenity-js/console-reporter": "^3.0.0",
+    "@serenity-js/core": "^3.0.0",
+    "@serenity-js/playwright": "^3.0.0",
+    "@serenity-js/playwright-test": "^3.0.0",
+    "@serenity-js/serenity-bdd": "^3.0.0",
+    "@serenity-js/web": "^3.0.0",
+    "@types/node": "^22.0.0"
   },
   "dependencies": {
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.0.0"
   }
 }

--- a/test/find-e2e-tests/playwright.config.ts
+++ b/test/find-e2e-tests/playwright.config.ts
@@ -60,15 +60,10 @@ export default defineConfig<SerenityOptions>({
     /* Configure projects for major browsers */
     projects: [
         {
-            name: 'Microsoft Edge',
+            name: 'chromium',
             use: {
-                channel: 'msedge',
-            },
-        },
-        {
-            name: 'Google Chrome',
-            use: {
-                channel: 'chrome',
+                ...devices['Desktop Chrome'],
+                channel: 'chromium',
             },
         },
         {

--- a/test/find-e2e-tests/playwright.config.ts
+++ b/test/find-e2e-tests/playwright.config.ts
@@ -60,10 +60,9 @@ export default defineConfig<SerenityOptions>({
     /* Configure projects for major browsers */
     projects: [
         {
-            name: 'chromium',
+            name: 'Chromium',
             use: {
                 ...devices['Desktop Chrome'],
-                channel: 'chromium',
             },
         },
         {

--- a/test/manage-e2e-tests/package-lock.json
+++ b/test/manage-e2e-tests/package-lock.json
@@ -9,18 +9,18 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.0.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.48.1",
-        "@serenity-js/assertions": "^3.29.4",
-        "@serenity-js/console-reporter": "^3.29.4",
-        "@serenity-js/core": "^3.29.4",
-        "@serenity-js/playwright": "^3.29.4",
-        "@serenity-js/playwright-test": "^3.29.4",
-        "@serenity-js/serenity-bdd": "^3.29.4",
-        "@serenity-js/web": "^3.29.4",
-        "@types/node": "^22.8.0"
+        "@playwright/test": "^1.0.0",
+        "@serenity-js/assertions": "^3.0.0",
+        "@serenity-js/console-reporter": "^3.0.0",
+        "@serenity-js/core": "^3.0.0",
+        "@serenity-js/playwright": "^3.0.0",
+        "@serenity-js/playwright-test": "^3.0.0",
+        "@serenity-js/serenity-bdd": "^3.0.0",
+        "@serenity-js/web": "^3.0.0",
+        "@types/node": "^22.0.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/test/manage-e2e-tests/package.json
+++ b/test/manage-e2e-tests/package.json
@@ -10,17 +10,17 @@
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "^1.48.1",
-    "@serenity-js/assertions": "^3.29.4",
-    "@serenity-js/console-reporter": "^3.29.4",
-    "@serenity-js/core": "^3.29.4",
-    "@serenity-js/playwright": "^3.29.4",
-    "@serenity-js/playwright-test": "^3.29.4",
-    "@serenity-js/serenity-bdd": "^3.29.4",
-    "@serenity-js/web": "^3.29.4",
-    "@types/node": "^22.8.0"
+    "@playwright/test": "^1.0.0",
+    "@serenity-js/assertions": "^3.0.0",
+    "@serenity-js/console-reporter": "^3.0.0",
+    "@serenity-js/core": "^3.0.0",
+    "@serenity-js/playwright": "^3.0.0",
+    "@serenity-js/playwright-test": "^3.0.0",
+    "@serenity-js/serenity-bdd": "^3.0.0",
+    "@serenity-js/web": "^3.0.0",
+    "@types/node": "^22.0.0"
   },
   "dependencies": {
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.0.0"
   }
 }

--- a/test/manage-e2e-tests/playwright.config.ts
+++ b/test/manage-e2e-tests/playwright.config.ts
@@ -65,15 +65,10 @@ export default defineConfig<SerenityOptions>({
     /* Configure projects for major browsers */
     projects: [
         {
-            name: 'Microsoft Edge',
+            name: 'chromium',
             use: {
-                channel: 'msedge',
-            },
-        },
-        {
-            name: 'Google Chrome',
-            use: {
-                channel: 'chrome',
+                ...devices['Desktop Chrome'],
+                channel: 'chromium',
             },
         },
         // Firefox & Safari have a temporary workaround to ignore HTTPS errors due to a bug around TLS certificates.

--- a/test/manage-e2e-tests/playwright.config.ts
+++ b/test/manage-e2e-tests/playwright.config.ts
@@ -65,10 +65,9 @@ export default defineConfig<SerenityOptions>({
     /* Configure projects for major browsers */
     projects: [
         {
-            name: 'chromium',
+            name: 'Chromium',
             use: {
                 ...devices['Desktop Chrome'],
-                channel: 'chromium',
             },
         },
         // Firefox & Safari have a temporary workaround to ignore HTTPS errors due to a bug around TLS certificates.


### PR DESCRIPTION
Chromium has updated their headless browser to be more in line with their headed browser and now in turn Google Chrome and MS Edge run in headless mode (not headed mode).  Playwright has also implemented this change in their browsers in v1.49 (latest is v.1.50).

This means instead of explicitly calling out Google Chrome and MS Edge in playwright config as our browsers to test we can just call the headless chromium shell instead (previously we couldn't as that was not an accurate representation of google chrome or ms edge as they used a headed shell).
When we install Google Chrome and MS Edge using npx playwright install to run our E2E tests against we install headed and headless browsers - however the headed versions aren't needed anymore so we can change that command to npx playwright install --no-shell  now.

https://github.com/microsoft/playwright/issues/33566 this was my ref

![image](https://github.com/user-attachments/assets/7f48d557-9962-477d-b9b5-c46ef31e5cd8)


Failures in manage are due to auth issues.
