### PR TITLE
Migrate ADRs to repository format

### DIFF
--- a/docs/arch/ADR001-use-http-for-inter-service-comms.md
+++ b/docs/arch/ADR001-use-http-for-inter-service-comms.md
@@ -6,7 +6,8 @@
 
 ## Decision
 
-HTTP will be used for inter-service communication. No message queue (RabbitMQ or otherwise) shall be used.
+HTTP will be used for inter-service communication. No message queue (RabbitMQ or
+otherwise) shall be used.
 
 ## Options considered
 

--- a/docs/arch/ADR001-use-http-for-inter-service-comms.md
+++ b/docs/arch/ADR001-use-http-for-inter-service-comms.md
@@ -1,0 +1,20 @@
+# ADR001 - Use HTTP for inter-service communications
+
+- **Status**: Adopted
+- **Date**: 2022-10-04
+- **Author**: Unknown
+
+## Decision
+
+HTTP will be used for inter-service communication. No message queue (RabbitMQ or otherwise) shall be used.
+
+## Options considered
+
+1. (SELECTED) 'Simple HTTP'
+2. A message queue
+
+## Consequences
+
+### Option 1 - Simple HTTP
+
+- If an API call fails, we potentially lose the data in the call.

--- a/docs/arch/ADR002-use-a-managed-azure-database.md
+++ b/docs/arch/ADR002-use-a-managed-azure-database.md
@@ -1,0 +1,14 @@
+# ADR002 - Use a managed Azure database
+
+- **Status**: Adopted
+- **Date**: 2022-10-04
+- **Author**: Unknown
+
+## Decision
+
+A managed Azure database will be used for data storage.
+
+## Options considered
+
+1. (SELECTED) Managed Azure database
+2. Docker images

--- a/docs/arch/ADR004-use-aspdotnet-identity-auth.md
+++ b/docs/arch/ADR004-use-aspdotnet-identity-auth.md
@@ -1,0 +1,40 @@
+# ADR004 - Use ASP.NET Identity Authentication
+
+- **Status**: Superceded by ADR008
+- **Date**: 2022-10-04
+- **Author**: Unknown
+
+## Decision
+
+ASP.NET Identity will be used to authenticate users of the family hubs services.
+
+## Options considered
+
+1. (SELECTED) ASP.NET Identity
+2. IdentityServer
+3. Azure AD B2C
+4. GOV.UK Sign-in
+5. DfE Sign-in
+
+## Consequences
+
+### Option 1 - ASP.NET Identity
+
+- Can be customised because the source code is available.
+- The team has an added responsibility for the security of stored user accounts and passwords.
+
+### Option 2 - IdentityServer
+
+- Would require a paid licence.
+
+### Option 3 - Azure AD B2C
+
+- A seaparte Azure AD tenant would be required for each LA and VCF organisation. This would be onerous for the support desk.
+
+### Option 4 - GOV.UK Sign-in
+
+- Does not provide features for login organisations.
+
+### Option 5 - DfE Sign-in
+
+- Requires users to have an education.gov.uk account, which VCF users would not have.

--- a/docs/arch/ADR004-use-aspdotnet-identity-auth.md
+++ b/docs/arch/ADR004-use-aspdotnet-identity-auth.md
@@ -21,7 +21,8 @@ ASP.NET Identity will be used to authenticate users of the family hubs services.
 ### Option 1 - ASP.NET Identity
 
 - Can be customised because the source code is available.
-- The team has an added responsibility for the security of stored user accounts and passwords.
+- The team has an added responsibility for the security of stored user accounts
+  and passwords.
 
 ### Option 2 - IdentityServer
 
@@ -29,7 +30,8 @@ ASP.NET Identity will be used to authenticate users of the family hubs services.
 
 ### Option 3 - Azure AD B2C
 
-- A seaparte Azure AD tenant would be required for each LA and VCF organisation. This would be onerous for the support desk.
+- A seaparte Azure AD tenant would be required for each LA and VCF organisation.
+  This would be onerous for the support desk.
 
 ### Option 4 - GOV.UK Sign-in
 

--- a/docs/arch/ADR006-redis-for-session-storage.md
+++ b/docs/arch/ADR006-redis-for-session-storage.md
@@ -10,5 +10,5 @@ A redis cache will be used for session storage.
 
 ## Context
 
-The need for session storage came from needing to implement a 'stack frame' to record pages and ensure
-proper 'back button' functionality in the Admin UI.
+The need for session storage came from needing to implement a 'stack frame' to
+record pages and ensure proper 'back button' functionality in the Admin UI.

--- a/docs/arch/ADR006-redis-for-session-storage.md
+++ b/docs/arch/ADR006-redis-for-session-storage.md
@@ -1,0 +1,14 @@
+# ADR006 - Use Redis for session storage
+
+- **Status**: Superceded by ADR010
+- **Date**: 2022-10-26
+- **Author**: Unknown
+
+## Decision
+
+A redis cache will be used for session storage.
+
+## Context
+
+The need for session storage came from needing to implement a 'stack frame' to record pages and ensure
+proper 'back button' functionality in the Admin UI.

--- a/docs/arch/ADR007-use-azure-app-services.md
+++ b/docs/arch/ADR007-use-azure-app-services.md
@@ -6,7 +6,8 @@
 
 ## Decision
 
-Applications in the family hub services will be directly deployed to Azure App Services.
+Applications in the family hub services will be directly deployed to Azure App
+Services.
 
 ## Options considered
 
@@ -18,7 +19,8 @@ Applications in the family hub services will be directly deployed to Azure App S
 ### Option 1 - Azure App Services
 
 - More effort to migrate family hubs to another cloud provider.
-- Brings the family hubs architecture more in line with the 'Apprenticeship service' which is considered the exemplar in the DfE.
+- Brings the family hubs architecture more in line with the 'Apprenticeship
+  service' which is considered the exemplar in the DfE.
 
 ### Option 2 - Container Apps
 

--- a/docs/arch/ADR007-use-azure-app-services.md
+++ b/docs/arch/ADR007-use-azure-app-services.md
@@ -1,0 +1,26 @@
+# ADR008 - Use Azure App Services for service hosting
+
+- **Status**: Adopted
+- **Date**: 2022-11-21
+- **Author**: Unknown
+
+## Decision
+
+Applications in the family hub services will be directly deployed to Azure App Services.
+
+## Options considered
+
+1. (SELECTED) Azure App Services
+2. Container Apps
+
+## Consequences
+
+### Option 1 - Azure App Services
+
+- More effort to migrate family hubs to another cloud provider.
+- Brings the family hubs architecture more in line with the 'Apprenticeship service' which is considered the exemplar in the DfE.
+
+### Option 2 - Container Apps
+
+- Less effort to migrate family hubs to another cloud provider.
+- Requires more effort to build and maintain hosting environments.

--- a/docs/arch/ADR008-use-govuk-one-login-auth.md
+++ b/docs/arch/ADR008-use-govuk-one-login-auth.md
@@ -1,0 +1,28 @@
+# ADR008 - Use GOV.UK One Login for authentication
+
+- **Status**: Adopted
+- **Date**: 2023-04-04
+- **Author**: Unknown
+
+## Decision
+
+Use GOV.UK One Login to authenticate users to the family hubs services.
+
+## Context
+
+After adopting ASP.NET Identity in ADR004, it was found to not conform to the 
+OpenId Connect (OIDC) protocol.
+
+## Options considered
+
+1. (SELECTED) Adopt GOV.UK One Login
+2. Identity Server 4
+3. Identity Server 6
+
+## Consequences
+
+### Option 1 - Adopt GOV.UK One Login
+
+-  Would conform to the OIDC protocol.
+-  Transfers some security risk to GOV.UK One Login.
+-  Requires reworking the user flow for the sign-up process.

--- a/docs/arch/ADR010-sql-server-caching.md
+++ b/docs/arch/ADR010-sql-server-caching.md
@@ -21,7 +21,6 @@ After quite a lengthy investigation the issue was determined to be outside of
 our control most likely in the client library we were using so it was decided to
 investigate an alternate mechanism for the distributed cache.
 
-
 ## Options considered
 
 1. (SELECTED) Use SQL Server caching

--- a/docs/arch/ADR010-sql-server-caching.md
+++ b/docs/arch/ADR010-sql-server-caching.md
@@ -1,0 +1,58 @@
+# ADR010 - Use SQL Server caching for session storage
+
+- **Status**: Adopted 
+- **Date**: 2023-06-06
+- **Author**: Unknown
+
+## Decision
+
+<!-- 
+    In a few sentences, describe the decision taken. 
+-->
+
+## Context
+
+<!-- 
+    Describe the forces and circumstances that brought about this decision. 
+-->
+
+## Options considered
+
+<!-- 
+    Briefly describe each option considered as a numbered list. Start with the selected option.
+    It's usually wise to include a 'do nothing' option.
+
+    e.g.
+
+    1. (SELECTED) PostgreSQL
+    2. Oracle
+    3. SQL Server  
+-->
+
+## Consequences
+
+<!-- 
+    For each of the options above, describe positive and negative consequences
+    of selecting that option. Create a new section for each option under a heading.
+
+    Remember a law of architecture: There are no solutions, only trade-offs. Make
+    sure to include any negative consequences of the selected option.
+
+    e.g.
+
+    ### Option 1 - XXX
+
+    - Consequence 1
+    - Consequence 2
+
+    ### Option 2 - XXX
+
+    etc.
+-->
+
+## Advice
+
+<!--
+    List of advice gathered to make this decision, including the names and role of 
+    advisors and the date each piece of advice was gathered.
+-->

--- a/docs/arch/ADR010-sql-server-caching.md
+++ b/docs/arch/ADR010-sql-server-caching.md
@@ -6,53 +6,29 @@
 
 ## Decision
 
-<!-- 
-    In a few sentences, describe the decision taken. 
--->
+Use SQL Server caching for session storage.
 
 ## Context
 
-<!-- 
-    Describe the forces and circumstances that brought about this decision. 
--->
+We use a distributed cache (separate to the server a website is hosted on) to save the information collected on a given page in a User Journey between request post-backs (e.g. the User Journey for adding a service, the User Journey for a Professional referral and the User Journey for IdAMs) and encountered a number of issue with the Azure Managed Redis cache that resulted in the cache being unresponsive and returning an error. 
+
+After quite a lengthy investigation the issue was determined to be outside of our control most likely in the client library we were using so it was decided to investigate an alternate mechanism for the distributed cache.
+
 
 ## Options considered
 
-<!-- 
-    Briefly describe each option considered as a numbered list. Start with the selected option.
-    It's usually wise to include a 'do nothing' option.
-
-    e.g.
-
-    1. (SELECTED) PostgreSQL
-    2. Oracle
-    3. SQL Server  
--->
+1. (SELECTED) Use SQL Server caching
+2. Stick with Redis
 
 ## Consequences
 
-<!-- 
-    For each of the options above, describe positive and negative consequences
-    of selecting that option. Create a new section for each option under a heading.
+### Option 1 - Use SQL Server Caching
 
-    Remember a law of architecture: There are no solutions, only trade-offs. Make
-    sure to include any negative consequences of the selected option.
+- Simple to implement
+- May result in a slight performance reduction
+- Could increase database load
+- Saves costs, since SQL Server is already being used as the primary database
 
-    e.g.
+### Option 2 - Stick with Redis
 
-    ### Option 1 - XXX
-
-    - Consequence 1
-    - Consequence 2
-
-    ### Option 2 - XXX
-
-    etc.
--->
-
-## Advice
-
-<!--
-    List of advice gathered to make this decision, including the names and role of 
-    advisors and the date each piece of advice was gathered.
--->
+- Continuing errors and unresponsiveness on page loads

--- a/docs/arch/ADR010-sql-server-caching.md
+++ b/docs/arch/ADR010-sql-server-caching.md
@@ -10,9 +10,16 @@ Use SQL Server caching for session storage.
 
 ## Context
 
-We use a distributed cache (separate to the server a website is hosted on) to save the information collected on a given page in a User Journey between request post-backs (e.g. the User Journey for adding a service, the User Journey for a Professional referral and the User Journey for IdAMs) and encountered a number of issue with the Azure Managed Redis cache that resulted in the cache being unresponsive and returning an error. 
+We use a distributed cache (separate to the server a website is hosted on) to 
+save the information collected on a given page in a User Journey between 
+request post-backs (e.g. the User Journey for adding a service, the User 
+Journey for a Professional referral and the User Journey for IdAMs) and 
+encountered a number of issue with the Azure Managed Redis cache that resulted 
+in the cache being unresponsive and returning an error. 
 
-After quite a lengthy investigation the issue was determined to be outside of our control most likely in the client library we were using so it was decided to investigate an alternate mechanism for the distributed cache.
+After quite a lengthy investigation the issue was determined to be outside of
+our control most likely in the client library we were using so it was decided to
+investigate an alternate mechanism for the distributed cache.
 
 
 ## Options considered

--- a/docs/arch/ADR012-pull-data-from-external-orgs.md
+++ b/docs/arch/ADR012-pull-data-from-external-orgs.md
@@ -1,0 +1,24 @@
+# ADR012 - Pull directory data from external organisations
+
+- **Status**: Adopted
+- **Date**: 2024-08-06
+- **Author**: Unknown
+
+## Decision
+
+Pull directory data from external organisations which have open referral
+interfaces, in opposed to having the data pushed to family hubs.
+
+## Options considered
+
+1. (SELECTED) Pull directory data from external organisations
+2. Receive data pushed from external organisations
+
+## Consequences
+
+### Option 1 - Pull directory data from external organisations
+
+- Allows the family hubs service to ingest data without requiring changes at the
+  external organisation.
+- May need to evolve the database schema, due to a lack of 'created by' User IDs 
+  when gathering data.

--- a/docs/arch/ADR013-ingest-into-staging-schema.md
+++ b/docs/arch/ADR013-ingest-into-staging-schema.md
@@ -1,0 +1,36 @@
+# ADR013 - Ingest service data into a 'staging schema'
+
+- **Status**: Adopted
+- **Date**: 2024-08-06
+- **Author**: Unknown
+
+## Decision
+
+Data ingested from external sources will be loaded into a separate 'staging' schema
+within the existing service directory database. This is in opposition to maintaining
+separate databases for this purpose.
+
+## Context
+
+New guidelines were given recently with regard to the number of organisation and
+users that reduces the scaling requirements of the Family Hubs products. An opportunity was
+seen to simplify the architecture by reducing the need for multiple databases.
+
+## Options considered
+
+1. (SELECTED) Ingest data into a 'staging schema' in the service directory database
+2. Do nothing, keeping the existing multi-database structure
+
+## Consequences
+
+### Option 1 - Staging schema
+
+- Would simplify the architecture and be a step towards a 'modular monolith'
+  architecture style.
+- Reduces the scale capability of the services to 25 local authorities with 100
+  VCFS organisations.
+
+### Option 2 - Do nothing
+
+- Would maintain the current high scale capability of 152 local authorities with
+  1000 VCFS organisations.

--- a/docs/arch/ADR020-create-mock-api-to-stub-las.md
+++ b/docs/arch/ADR020-create-mock-api-to-stub-las.md
@@ -1,0 +1,28 @@
+# ADR020 - Create an ASP.NET API to stub local authorities during development
+
+- **Status**: Adopted
+- **Date**: 2024-08-06
+- **Author**: Unknown
+
+## Decision
+
+A stub API will be created in ASP.NET to send requests against while developing
+open referral integration capabilities.
+
+## Context
+
+Open referral (OR) ingestion capabilities need to be developed before the
+OR-compliant API has been created by Somerset Council.
+
+An approach was needed to unblock developers from this dependency.
+
+## Options considered
+
+1. (SELECTED) Create a mock API as an ASP.NET API
+
+## Consequences
+
+### Option 1 - Create a mock API as an ASP.NET API
+
+- Allows controlling the data returned from the API, giving flexibility to
+  simulate many test scenarios.

--- a/docs/arch/ADR025-use-sonar-cloud.md
+++ b/docs/arch/ADR025-use-sonar-cloud.md
@@ -1,0 +1,26 @@
+# ADR025 - Use SonarCloud in 'monitoring mode'
+
+- **Status**: Adopted
+- **Date**: 2024-12-10
+- **Author**: Unknown
+
+## Decision
+
+SonarCloud scanning tools will be used to detect issues in code quality. The
+'monitoring mode' will be set, causing a new scan to start on every push to the
+main or release branches.
+
+## Context
+
+An initial scan of SonarCloud on the family hubs service repository branches
+revealed that they did not meet the thresholds for any quality checks. 
+
+## Options considered
+
+1. (SELECTED) Use SonarCloud in 'monitoring mode'
+
+## Consequences
+
+### Option 1 - Use SonarCloud in 'monitoring mode'
+
+- Would apply DfE-wide rules on code quality to the family hubs service.

--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -1,0 +1,18 @@
+# Architecture decision records (ADR)
+
+All architectural decisions must be logged within this directory.
+
+To create an ADR: 
+
+1. Make a copy of [TEMPLATE.md](./TEMPLATE.md).
+2. Complete the given sections in the template.
+3. Submit a pull request to propose the ADR.
+4. Work through any feedback until the ADR is accepted or rejected.
+
+Please note that not all technical decisions are architectural decisions. An architectural decision relates to:
+
+- changes at the module (such as dotnet namespace) or component level (structural changes)
+- architectural characteristcs (also known as  NFRs or CFRs)
+- dependencies
+- external interfaces
+- construction techniques

--- a/docs/arch/TEMPLATE.md
+++ b/docs/arch/TEMPLATE.md
@@ -1,0 +1,66 @@
+<!-- 
+    Choose an identifier for the ADR by adding 1 to the previous ADR's id. 
+
+    Also choose a title, which should be a very short description of the 
+    decision itself. Make it specific.    
+-->
+
+# <!-- Identifier: --> ADRXXX - <!-- Title: --> TITLE
+
+<!-- Metadata section. All fields are mandatory. -->
+- **Status**: Draft
+- **Date**: <!-- The day the draft was started, in the YYYY-MM-DD format, for example '1970-01-01' -->
+- **Author**:<!-- Your full name as the owner of the decision, for example 'Joe Bloggs'. -->
+
+## Decision
+
+<!-- 
+    In a few sentences, describe the decision taken. 
+-->
+
+## Context
+
+<!-- 
+    Describe the forces and circumstances that brought about this decision. 
+-->
+
+## Options considered
+
+<!-- 
+    Briefly describe each option considered as a numbered list. Start with the selected option.
+    It's usually wise to include a 'do nothing' option.
+
+    e.g.
+
+    1. (SELECTED) PostgreSQL
+    2. Oracle
+    3. SQL Server  
+-->
+
+## Consequences
+
+<!-- 
+    For each of the options above, describe positive and negative consequences
+    of selecting that option. Create a new section for each option under a heading.
+
+    Remember a law of architecture: There are no solutions, only trade-offs. Make
+    sure to include any negative consequences of the selected option.
+
+    e.g.
+
+    ### Option 1 - XXX
+
+    - Consequence 1
+    - Consequence 2
+
+    ### Option 2 - XXX
+
+    etc.
+-->
+
+## Advice
+
+<!--
+    List of advice gathered to make this decision, including the names and role of 
+    advisors and the date each piece of advice was gathered.
+-->

--- a/docs/arch/TEMPLATE.md
+++ b/docs/arch/TEMPLATE.md
@@ -63,4 +63,7 @@
 <!--
     List of advice gathered to make this decision, including the names and role of 
     advisors and the date each piece of advice was gathered.
+
+    Before submitting a decision, you are expected to gather advice from all team 
+    members or stakeholders who will be affected by the decision.
 -->


### PR DESCRIPTION
Adds a new 'adr' folder to the in-repository documentation. Contains the ADRs from confluence 
which were assessed as architectural decisions -- not technical decisions or decisions about
service scope.

The remaining decisions will be archived unless I'm otherwise directed.  
