### PR TITLE
fix(Connect): FHB-1188 - VCFS User still sees "My Requests" Tab

### DIFF
--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/Options/Configure/FamilyHubsUiOptionsConfigure.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/Options/Configure/FamilyHubsUiOptionsConfigure.cs
@@ -51,11 +51,16 @@ public class FamilyHubsUiOptionsConfigure : IConfigureOptions<FamilyHubsUiOption
         {
             return;
         }
-        
-        if (!_featureManager.IsEnabledAsync(FeatureFlag.ConnectDashboard).Result)
+
+        if (_featureManager.IsEnabledAsync(FeatureFlag.ConnectDashboard).Result)
         {
-            options.Header.NavigationLinks = [ options.Header.NavigationLinks[0] ];
+            return;
         }
+        
+        FhLinkOptions serviceSearchHeaderLink = 
+            options.Header.NavigationLinks.First(headerLink => headerLink.Text.Equals("Search for service"));
+            
+        options.Header.NavigationLinks = [ serviceSearchHeaderLink ];
     }
 
     private void ConfigureLinks(FhLinkOptions[] linkOptions, FamilyHubsUiOptions options)

--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/Options/Configure/FamilyHubsUiOptionsConfigure.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FamilyHubsUi/Options/Configure/FamilyHubsUiOptionsConfigure.cs
@@ -33,7 +33,8 @@ public class FamilyHubsUiOptionsConfigure : IConfigureOptions<FamilyHubsUiOption
             .Where(kvp => kvp.Value.Enabled)
             .Select(kvp => kvp);
 
-        // turtles all the way down
+        // Recursively generates header permutations for each section defined in "AlternativeFamilyHubsUi" ..
+        // .. in appsettings.json
         foreach (var alt in enabledAlts)
         {
             Configure(alt.Value, alt.Key, options);

--- a/src/shared/web-components/tests/FamilyHubs.SharedKernel.Razor.UnitTests/FamilyHubsUi/Configure/FamilyHubsUiOptionsConfigureTests.cs
+++ b/src/shared/web-components/tests/FamilyHubs.SharedKernel.Razor.UnitTests/FamilyHubsUi/Configure/FamilyHubsUiOptionsConfigureTests.cs
@@ -50,7 +50,7 @@ public class FamilyHubsUiOptionsConfigureTests : FamilyHubsUiOptionsTestBase
         _familyHubsUiOptionsConfigure.Configure(FamilyHubsUiOptions);
         
         FamilyHubsUiOptions.Header.NavigationLinks.Should().HaveCount(2);
-        FamilyHubsUiOptions.Header.NavigationLinks[0].Text.Should().Be("Search for a Service");
+        FamilyHubsUiOptions.Header.NavigationLinks[0].Text.Should().Be("Search for service");
         FamilyHubsUiOptions.Header.NavigationLinks[1].Text.Should().Be("My Requests");
     }
     
@@ -62,7 +62,7 @@ public class FamilyHubsUiOptionsConfigureTests : FamilyHubsUiOptionsTestBase
         _familyHubsUiOptionsConfigure.Configure(FamilyHubsUiOptions);
         
         FamilyHubsUiOptions.Header.NavigationLinks.Should().ContainSingle();
-        FamilyHubsUiOptions.Header.NavigationLinks[0].Text.Should().Be("Search for a Service");
+        FamilyHubsUiOptions.Header.NavigationLinks[0].Text.Should().Be("Search for service");
     }
 
     [Theory]

--- a/src/shared/web-components/tests/FamilyHubs.SharedKernel.Razor.UnitTests/FamilyHubsUi/Configure/Helpers/FamilyHubsUiOptionsTestBase.cs
+++ b/src/shared/web-components/tests/FamilyHubs.SharedKernel.Razor.UnitTests/FamilyHubsUi/Configure/Helpers/FamilyHubsUiOptionsTestBase.cs
@@ -26,7 +26,7 @@ public class FamilyHubsUiOptionsTestBase
                 {
                     new FhLinkOptions
                     {
-                        Text = "Search for a Service",
+                        Text = "Search for service",
                         Url = "https://example.com/first",
                         ConfigUrl = null
                     },


### PR DESCRIPTION
Ticket: [FHB-1188](https://dfedigital.atlassian.net/browse/FHB-1188)

---

This PR:

- Fixes an issue where when logging in as a VCFS user with the Connect Dashboard turned off, you would still have one tab as expected but it would be the "My Requests" one instead of "Search for a Service". This happened because the UI generates each permutation of the navigation tabs on startup to cater for each user type, and VCFS users swap the ordering and so using the 1st tab wasn't sufficient. I have updated the comment above the logic that does this to actually explain it.

[FHB-1188]: https://dfedigital.atlassian.net/browse/FHB-1188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ