### PR TITLE
fix(Connect): FHB-1247 - Postcode Search Text Box Screen Reader

### DIFF
--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Search.cshtml
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Search.cshtml
@@ -30,14 +30,14 @@
         
         <form method="post" novalidate>
             <div class="govuk-form-group @(error?.FormGroupClass)" id="search-options">
-                <label class="govuk-label govuk-label--s" for="Postcode">
+                <label class="govuk-label govuk-label--s" for="postcode">
                     Enter a postcode
                 </label>
-                <div id="account-number-hint" class="govuk-hint">
+                <div id="postcode-services-hint" class="govuk-hint">
                     For example SW1A 2AA
                 </div>
                 <partial name="_ErrorMessageNext" model="error"/>
-                <input class="govuk-input govuk-input--width-10 @(error?.InputClass)" id="postcode" name="Postcode" type="text" spellcheck="false" value="@Model.Postcode" data-testid="postcode-value">
+                <input class="govuk-input govuk-input--width-10 @(error?.InputClass)" aria-describedby="postcode-services-hint" id="postcode" name="Postcode" type="text" spellcheck="false" value="@Model.Postcode" data-testid="postcode-value">
             </div>
             <button type="submit" class="govuk-button govuk-!-padding-left-3 govuk-!-padding-right-3" data-testid="button-search">
                 Search


### PR DESCRIPTION
Ticket: [FHB-1247](https://dfedigital.atlassian.net.mcas.ms/browse/FHB-1247)

---

This PR:

- Fixes the screen reader on the postcode search page (specifically the text box). It never worked in Connect, but it did in Find, so I've just copied over the code from there. Tested it by running prod Find & this branch locally at the same time with a screen reader running and ensuring they were reading the same things when tabbing over the postcode search field.

[FHB-1247]: https://dfedigital.atlassian.net/browse/FHB-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ