### PR TITLE
feat: FHB-71 Profanity check

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -80,6 +80,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="8.0.8" />
+    <PackageVersion Include="Profanity.Detector" Version="0.1.8" />
     <PackageVersion Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/function/open-referral-function/src/FamilyHubs.OpenReferral.Function/Functions/TriggerPullServicesWebhook.cs
+++ b/src/function/open-referral-function/src/FamilyHubs.OpenReferral.Function/Functions/TriggerPullServicesWebhook.cs
@@ -4,6 +4,7 @@ using FamilyHubs.OpenReferral.Function.ClientServices;
 using FamilyHubs.OpenReferral.Function.Repository;
 using FamilyHubs.SharedKernel.Factories;
 using FamilyHubs.SharedKernel.OpenReferral.Entities;
+using FamilyHubs.SharedKernel.Utilities;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -47,9 +48,9 @@ public class TriggerPullServicesWebhook(
     private async Task ClearDatabase()
     {
         logger.LogInformation("Removing all services from the database");
-        List<Service> serviceListFromDb = await functionDbContext.ToListAsync(functionDbContext.Services());
+        var serviceListFromDb = await functionDbContext.ToListAsync(functionDbContext.Services());
 
-        foreach (Service service in serviceListFromDb)
+        foreach (var service in serviceListFromDb)
         {
             logger.LogInformation("Removing service from the database, Internal ID = {iId} | Open Referral ID = {oId}",
                 service.Id, service.OrId);
@@ -61,11 +62,20 @@ public class TriggerPullServicesWebhook(
 
     private async Task UpdateDatabase(List<Service> serviceListFromApi)
     {
-        foreach (Service service in serviceListFromApi)
+        foreach (var service in serviceListFromApi)
         {
+            var hasProfanity = ProfanityChecker.HasProfanity(service);
+            if (hasProfanity)
+            {
+                logger.LogWarning("Service with OR ID {OrId} contains profanity and will not be added to the database", service.OrId);
+                continue;
+            }
+            
             var factory = SanitizerFactory.CreateDedsTextSanitizer();
             logger.LogInformation("Sanitizing service with ID {serviceId}", service.OrId);
             var sanitizedService = factory.Sanitize(service);
+            
+            
             
             logger.LogInformation("Adding service with ID {serviceId} to the database", service.OrId);
             functionDbContext.AddService(sanitizedService);

--- a/src/function/open-referral-function/src/FamilyHubs.OpenReferral.Function/Functions/TriggerPullServicesWebhook.cs
+++ b/src/function/open-referral-function/src/FamilyHubs.OpenReferral.Function/Functions/TriggerPullServicesWebhook.cs
@@ -71,9 +71,9 @@ public class TriggerPullServicesWebhook(
                 continue;
             }
             
-            var factory = SanitizerFactory.CreateDedsTextSanitizer();
+            var textSanitizer = SanitizerFactory.CreateDedsTextSanitizer();
             logger.LogInformation("Sanitizing service with ID {serviceId}", service.OrId);
-            var sanitizedService = factory.Sanitize(service);
+            var sanitizedService = textSanitizer.Sanitize(service);
             
             
             

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Factories/SanitizerFactory.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Factories/SanitizerFactory.cs
@@ -8,7 +8,6 @@ public static class SanitizerFactory
     {
         return new StringSanitizer()
             .RemoveHtml()
-            .RemoveJs()
-            .RemoveProfanity();
+            .RemoveJs();
     }
 }

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Factories/SanitizerFactory.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Factories/SanitizerFactory.cs
@@ -8,6 +8,7 @@ public static class SanitizerFactory
     {
         return new StringSanitizer()
             .RemoveHtml()
-            .RemoveJs();
+            .RemoveJs()
+            .RemoveProfanity();
     }
 }

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
@@ -42,6 +42,7 @@
 	  <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" />
 	  <PackageReference Include="Microsoft.IdentityModel.KeyVaultExtensions" />
 	  <PackageReference Include="Newtonsoft.Json" />
+	  <PackageReference Include="Profanity.Detector" />
 	  <PackageReference Include="Serilog.Sinks.AzureBlobStorage" />
 	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
 	  <PackageReference Include="Serilog" />

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Services/Sanitizers/StringSanitizer.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Services/Sanitizers/StringSanitizer.cs
@@ -49,11 +49,6 @@ public partial class StringSanitizer : IStringSanitizer
     public string Sanitize(string input)
     {
         
-        return SanitizeString(input);
-    }
-    
-    private string SanitizeString(string input)
-    {
         var sanitizedHtml = input;
         
         if (_removeJs)

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Services/Sanitizers/StringSanitizer.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Services/Sanitizers/StringSanitizer.cs
@@ -18,6 +18,7 @@ public partial class StringSanitizer : IStringSanitizer
 {
     private bool _removeHtml;
     private bool _removeJs;
+    private bool _removeProfanity;
 
     internal StringSanitizer RemoveHtml()
     {
@@ -28,6 +29,12 @@ public partial class StringSanitizer : IStringSanitizer
     internal StringSanitizer RemoveJs()
     {
         _removeJs = true;
+        return this;
+    }
+    
+    internal StringSanitizer RemoveProfanity()
+    {
+        _removeProfanity = true;
         return this;
     }
 
@@ -53,7 +60,26 @@ public partial class StringSanitizer : IStringSanitizer
         if (_removeHtml)
         { 
             sanitizedHtml = RemoveHtml(sanitizedHtml);
-            return sanitizedHtml;
+        }
+
+        if (_removeProfanity)
+        {
+            sanitizedHtml = RemoveProfanity(sanitizedHtml);
+        }
+
+        return sanitizedHtml;
+    }
+    
+    private static string RemoveProfanity(string input)
+    {
+        var sanitizedHtml = input;
+        var profanityFilter = new ProfanityFilter.ProfanityFilter();
+        var allProfanities = profanityFilter.DetectAllProfanities(input);
+        
+        if (allProfanities is not null && allProfanities.Count > 0)
+        {
+            sanitizedHtml = allProfanities.Aggregate(input, 
+                (current, profanity) => current.Replace(profanity, ""));
         }
 
         return sanitizedHtml;

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Utilities/ProfanityChecker.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Utilities/ProfanityChecker.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace FamilyHubs.SharedKernel.Utilities;
+
+public static class ProfanityChecker
+{
+    private static readonly ProfanityFilter.ProfanityFilter ProfanityFilter = new();
+
+    public static bool HasProfanity<T>([DisallowNull]T obj) where T : class
+    {
+        var hasProfanity = false;
+        PropertyInspector.InspectStringProperties(obj, (propertyName, parent, property) =>
+        {
+            var value = (string?)property.GetValue(parent);
+            if (value != null && ProfanityFilter.ContainsProfanity(value))
+            {
+                hasProfanity = true;
+            }
+        });
+        return hasProfanity;
+    }
+}
+

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Utilities/PropertyInspector.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Utilities/PropertyInspector.cs
@@ -12,7 +12,11 @@ public static class PropertyInspector
 
         foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
-            var value = property.GetValue(obj)!;
+            var value = property.GetValue(obj);
+            if (value is null)
+            {
+                continue;
+            }
             
             if (property.PropertyType == typeof(string))
             {

--- a/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Utilities/PropertyInspector.cs
+++ b/src/shared/shared-kernel/src/fh-shared-kernel.shared-kernel/Utilities/PropertyInspector.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Reflection;
+
+namespace FamilyHubs.SharedKernel.Utilities;
+
+public static class PropertyInspector
+{
+    public static void InspectStringProperties(object? obj, Action<string, object, PropertyInfo> action)
+    {
+        if (obj == null) return;
+        var type = obj.GetType();
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var value = property.GetValue(obj)!;
+            
+            if (property.PropertyType == typeof(string))
+            {
+                action(property.Name, obj, property); // Perform action on string properties
+            }
+            else if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType) && 
+                     property.PropertyType != typeof(string)) // Handle collections
+            {
+                if (value is IEnumerable collection)
+                {
+                    foreach (var item in collection)
+                    {
+                        InspectStringProperties(item, action);
+                    }
+                }
+            }
+            else if (property.PropertyType.IsClass) // Handle nested objects
+            {
+                InspectStringProperties(value, action);
+            }
+        }
+    }
+}

--- a/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/Services/SanitizerTests.cs
+++ b/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/Services/SanitizerTests.cs
@@ -70,6 +70,26 @@ public class SanitizerTests
         Assert.Equal("Test from mock three", result.MockClassTwo!.MockClassThree!.Name);
         
     }
+    
+    [Fact]
+    public void ShouldRemoveProfanity_WhenUsingDedsTextSanitizer()
+    {
+        // Arrange
+        var service = new MockClass
+        {
+            Name = "This is a test with some profanity weirdo",
+            Description = "",
+            Url = "",
+        };
+        
+        // Act
+        var sanitizer = SanitizerFactory.CreateDedsTextSanitizer();
+        var result = sanitizer.Sanitize(service);
+        
+        // Assert
+        Assert.Equal("This is a test with some profanity ", result.Name);
+        
+    }
 
     private class MockClass
     {

--- a/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/Services/SanitizerTests.cs
+++ b/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/Services/SanitizerTests.cs
@@ -53,7 +53,18 @@ public class SanitizerTests
                 MockClassThree = new MockClassThree()
                 {
                     Name = "<div>Test from mock three</div>"
-                }}
+                }},
+            MockClassTwos = new MockClassTwo[]
+            {
+                new MockClassTwo()
+                {
+                    Id = "<div>Test</div>",
+                    MockClassThree = new MockClassThree()
+                    {
+                        Name = "<div>Test</div>"
+                    }
+                }
+            }
         };
         
         // Act
@@ -68,26 +79,7 @@ public class SanitizerTests
         Assert.Equal(20.ToString(), result.Age.ToString());
         Assert.Equal(guid, result.MockClassTwo!.Id);
         Assert.Equal("Test from mock three", result.MockClassTwo!.MockClassThree!.Name);
-        
-    }
-    
-    [Fact]
-    public void ShouldRemoveProfanity_WhenUsingDedsTextSanitizer()
-    {
-        // Arrange
-        var service = new MockClass
-        {
-            Name = "This is a test with some profanity weirdo",
-            Description = "",
-            Url = "",
-        };
-        
-        // Act
-        var sanitizer = SanitizerFactory.CreateDedsTextSanitizer();
-        var result = sanitizer.Sanitize(service);
-        
-        // Assert
-        Assert.Equal("This is a test with some profanity ", result.Name);
+        Assert.Equal("Test", result.MockClassTwos.First().Id);
         
     }
 
@@ -101,6 +93,8 @@ public class SanitizerTests
         public string NotStandard => Name; // Checks that sanitizer handles non settable properties
         
         public MockClassTwo? MockClassTwo { get; set; }
+        
+        public MockClassTwo[] MockClassTwos { get; set; } = Array.Empty<MockClassTwo>();
     }
 
     private class MockClassTwo

--- a/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/Utilities/ProfanityCheckerTests.cs
+++ b/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/Utilities/ProfanityCheckerTests.cs
@@ -75,6 +75,7 @@ public class ProfanityCheckerTests
     private class MockClass
     {
         public required string Id { get; init; }
+        public string? Name { get; set; } = null;
         public required MockClassTwo MockClassTwo { get; set; }
         public MockClassTwo[] ListOfMockClassTwo { get; set; } = [];
         public MockClassTwo? NullableMockClassTwo { get; set; }

--- a/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/Utilities/ProfanityCheckerTests.cs
+++ b/src/shared/shared-kernel/tests/fh-shared-kernel.unit-tests/Utilities/ProfanityCheckerTests.cs
@@ -1,0 +1,87 @@
+using FamilyHubs.SharedKernel.OpenReferral.Entities;
+using FamilyHubs.SharedKernel.Utilities;
+
+namespace FamilyHubs.SharedKernel.UnitTests.Utilities;
+
+public class ProfanityCheckerTests
+{
+    [Fact]
+    public void ShouldReturnTrue_WhenClassContainsAnyProfanity()
+    {
+        // Arrange
+        var testClass = new MockClass
+        {
+            Id = "This has no profanity",
+            MockClassTwo = new MockClassTwo
+            {
+                Description = "This has profanity weirdo"
+            }
+        };
+        
+        // Act
+        var result = ProfanityChecker.HasProfanity(testClass);
+        
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void ShouldReturnTrue_WhenClassContainsAnyProfanityInNestedLists()
+    {
+        // Arrange
+        var testClass = new MockClass
+        {
+            Id = "This has no profanity",
+            MockClassTwo = new MockClassTwo
+            {
+                Description = "This has profanity",
+            },
+            ListOfMockClassTwo = new[]
+            {
+                new MockClassTwo
+                {
+                    Description = "This has profanity weirdo"
+                }
+            }
+        };
+        
+        // Act
+        var result = ProfanityChecker.HasProfanity(testClass);
+        
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void ShouldReturnFalse_WhenClassContainsNoProfanity()
+    {
+        // Arrange
+        var testClass = new MockClass
+        {
+            Id = "This has no profanity",
+            MockClassTwo = new MockClassTwo
+            {
+                Description = "This also has no profanity"
+            }
+        };
+        
+        // Act
+        var result = ProfanityChecker.HasProfanity(testClass);
+        
+        // Assert
+        Assert.False(result);
+    }
+    
+    private class MockClass
+    {
+        public required string Id { get; init; }
+        public required MockClassTwo MockClassTwo { get; set; }
+        public MockClassTwo[] ListOfMockClassTwo { get; set; } = [];
+        public MockClassTwo? NullableMockClassTwo { get; set; }
+    }
+    
+    private class MockClassTwo
+    {
+        public required string Description { get; set; }
+    }
+}


### PR DESCRIPTION
The list of words is not exhaustive so will not catch 100%, all profanity words that are default can be viewed in the library. https://www.nuget.org/packages/Profanity.Detector

The library itself does extensive unit testing so the one in this PR is just to ensure it is plugged in.

UPDATE:
Introduced a method to check properties that is re usable, and I fixed an issue with the string sanitizer where it was not checking on List type properties