### PR TITLE
Remove Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
Removes Renovate, an automatic dependency management tool. We haven't been using it so far, and Dependabot (built into GitHub) does the same thing, which is also recommended by GDS.

Info on Renovate here: https://github.com/renovatebot/renovate