### PR TITLE
FHB-1173 Remove redundant forward slash being added to connect redirects.

### DIFF
--- a/terraform/modules/fhinfrastructurestack/main.tf
+++ b/terraform/modules/fhinfrastructurestack/main.tf
@@ -1420,7 +1420,7 @@ resource "azurerm_application_gateway" "sd_ui_app_gateway" {
   redirect_configuration {
     name                 = "${var.prefix}-fh-redirect-to-connect-config"
     redirect_type        = "Permanent"
-    target_url           = "https://${var.connect_domain}/"
+    target_url           = "https://${var.connect_domain}"
     include_path         = true
     include_query_string = true
   }


### PR DESCRIPTION
Redirection of find to connect was adding a redundant forward slash on the redirect URL. Cases:

https://dev.find-support-for-your-family.education.gov.uk -> https://dev.connect-families-to-support.education.gov.uk//
https://dev.find-support-for-your-family.education.gov.uk/ -> https://dev.connect-families-to-support.education.gov.uk//
https://dev.find-support-for-your-family.education.gov.uk/terms-and-conditions -> https://dev.connect-families-to-support.education.gov.uk//terms-and-conditions

Test on an incognito browser as the double-slash effect is sticky if done once.