### PR TITLE
fix(Manage): FHB-1330 - LA Admin Users Cannot Add Organisations

### DIFF
--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/VcsAdmin/Pages/ManageOrganisations.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/VcsAdmin/Pages/ManageOrganisations.cshtml.cs
@@ -61,10 +61,12 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.VcsAdmin.Pages
             
             if (HttpContext.IsUserDfeAdmin())
             {
+                // DfE Admin gets asked to pick an LA on their next page, so clear it here
                 await _cacheService.ResetString(CacheKeyNames.LaOrganisationId); 
             }
             else
             {
+                // LA Admins can't pick an LA, so make sure the cache contains their ID before they go to their next page
                 await _cacheService.StoreString(CacheKeyNames.LaOrganisationId, 
                     HttpContext.GetFamilyHubsUser().OrganisationId);
             }

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/VcsAdmin/Pages/ManageOrganisations.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/VcsAdmin/Pages/ManageOrganisations.cshtml.cs
@@ -58,7 +58,12 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.VcsAdmin.Pages
         public async Task<IActionResult> OnGetAddOrganisation()
         {
             await _cacheService.StoreUserFlow("AddOrganisation");
-            await _cacheService.ResetString(CacheKeyNames.LaOrganisationId);
+            
+            if (HttpContext.IsUserDfeAdmin())
+            {
+                await _cacheService.ResetString(CacheKeyNames.LaOrganisationId); 
+            }
+            
             await _cacheService.ResetString(CacheKeyNames.AddOrganisationName);
 
             return RedirectToPage(HttpContext.IsUserDfeAdmin() ? "/AddOrganisationWhichLocalAuthority" : "/AddOrganisation", new { area = "vcsAdmin" });

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/VcsAdmin/Pages/ManageOrganisations.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/VcsAdmin/Pages/ManageOrganisations.cshtml.cs
@@ -63,6 +63,11 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.VcsAdmin.Pages
             {
                 await _cacheService.ResetString(CacheKeyNames.LaOrganisationId); 
             }
+            else
+            {
+                await _cacheService.StoreString(CacheKeyNames.LaOrganisationId, 
+                    HttpContext.GetFamilyHubsUser().OrganisationId);
+            }
             
             await _cacheService.ResetString(CacheKeyNames.AddOrganisationName);
 


### PR DESCRIPTION
Ticket: [FHB-1330](https://dfedigital.atlassian.net.mcas.ms/browse/FHB-1330)

---

Fixes a bug in Manage where DfE Admins can add VCFS Organisations but LA Admins (Manager/Dual Role) cannot.

This was because the "Add Organisation" link inside the Manage Organisation page reset the LA Org Id. This is fine for DfE Admins as their first page is "Which LA is this organisation in?" which then promptly sets the Org Id in the cache again. However LA Admins already have their LA Org Id pre-set and so clearing it here will make it empty/null with no way to set it again, therefore they would see a "Sorry something went wrong" page when trying to add an org.

[FHB-1330]: https://dfedigital.atlassian.net/browse/FHB-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ