### PR TITLE
[FHB-1002] Don't send an email when permissions have not been changed

### DIFF
--- a/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.UnitTests/Areas/AccountAdmin/ManagePermissions/EditRolesTests.cs
+++ b/src/ui/manage-ui/Test/FamilyHubs.ServiceDirectory.Admin.Web.UnitTests/Areas/AccountAdmin/ManagePermissions/EditRolesTests.cs
@@ -142,7 +142,8 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.UnitTests.Areas.AccountAdmin.Man
             _mockIdamClient.GetAccountById(Arg.Any<long>()).Returns(account);
             var sut = new EditRolesModel(_mockIdamClient, _mockEmailService)
             {
-                LaManager = true
+                // Set a different role to what the user has
+                LaProfessional = true
             };
             //  Act
             var result = await sut.OnPost(AccountId);

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/AccountAdmin/Pages/ManagePermissions/EditRoles.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/AccountAdmin/Pages/ManagePermissions/EditRoles.cshtml.cs
@@ -58,7 +58,15 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.AccountAdmin.Pages.ManageP
             {
                 var oldRole = GetRole(account);
                 var newRole = GetSelectedRole();
+
+                if (oldRole == newRole)
+                {
+                    // No updates required
+                    return RedirectToPage("EditRolesChangedConfirmation", new { AccountId = accountId });
+                }
+
                 SetOrganisationType(newRole);
+
                 var request = new UpdateClaimDto { AccountId = accountId, Name = "role", Value = newRole };
                 await _idamClient.UpdateClaim(request);
 
@@ -71,7 +79,8 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.AccountAdmin.Pages.ManageP
                 if (IsLa)
                 {
                     await _emailService.SendLaPermissionChangeEmail(email);
-                }else if ( IsVcs)
+                }
+                else if (IsVcs)
                 {
                     await _emailService.SendVcsPermissionChangeEmail(email);
                 }
@@ -122,14 +131,14 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.AccountAdmin.Pages.ManageP
 
         private void SetOrganisationType(string role)
         {
-            if (role == RoleTypes.LaManager || role == RoleTypes.LaProfessional || role == RoleTypes.LaDualRole)
+            switch (role)
             {
-                IsLa = true;
-            }
-            //Vcs
-            else if (role == RoleTypes.VcsManager || role == RoleTypes.VcsProfessional || role == RoleTypes.VcsDualRole)
-            {
-                IsVcs = true;
+                case RoleTypes.LaManager or RoleTypes.LaProfessional or RoleTypes.LaDualRole:
+                    IsLa = true;
+                    break;
+                case RoleTypes.VcsManager or RoleTypes.VcsProfessional or RoleTypes.VcsDualRole:
+                    IsVcs = true;
+                    break;
             }
         }
 


### PR DESCRIPTION
Calling the email service when old role and new role are equal causes it to throw an error as there's no template for that.
Just short circuiting the whole thing in this case and showing the success message.