### PR TITLE
[FHB-653] Fix something went wrong error when navigating back after deleting a user

### DIFF
--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/AccountAdmin/Pages/ManagePermissions/DeleteUser.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/AccountAdmin/Pages/ManagePermissions/DeleteUser.cshtml.cs
@@ -46,7 +46,7 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.AccountAdmin.Pages.ManageP
             _emailService = emailService;
         }
 
-        public async Task OnGet(long accountId)
+        public async Task<IActionResult> OnGet(long accountId)
         {
             BackUrl = await _cacheService.RetrieveLastPageName();
 
@@ -54,13 +54,15 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.AccountAdmin.Pages.ManageP
 
             if (account == null)
             {
-                throw new ArgumentException("User Account not found");
+                // User not found
+                return RedirectToPage("/ManagePermissions/Index");
             }
 
             UserName = account.Name;
             await _cacheService.StoreString("DeleteUserName", UserName);
-        }
 
+            return Page();
+        }
 
         public async Task<IActionResult> OnPost(long accountId)
         {

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/AccountAdmin/Pages/ManagePermissions/Edit.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/AccountAdmin/Pages/ManagePermissions/Edit.cshtml.cs
@@ -31,22 +31,22 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.AccountAdmin.Pages.ManageP
             _cacheService = cacheService;
         }
 
-        public async Task OnGet()
+        public async Task<IActionResult> OnGet()
         {
             await SetBackButton();
 
             if (!long.TryParse(AccountId, out long id))
             {
-                //todo: throw better exception
-                throw new InvalidOperationException("Invalid AccountId");
+                // Invalid AccountId
+                return RedirectToPage("/ManagePermissions/Index");
             }
 
             var account = await _idamClient.GetAccountById(id);
 
             if(account == null)
             {
-                //todo: throw better exception
-                throw new InvalidOperationException("User not found");
+                // User not found
+                return RedirectToPage("/ManagePermissions/Index");
             }
 
             var organisationName = await GetOrganisationName(account);
@@ -56,6 +56,8 @@ namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.AccountAdmin.Pages.ManageP
             Organisation = organisationName;
             Role = GetRoleText(account);
             Id = account.Id;
+
+            return Page();
         }
 
         private async Task<string> GetOrganisationName(AccountDto account)


### PR DESCRIPTION
Redirect back to the user list instead of throwing an error when a user can't be found.
The reported way to trigger this error is navigating back after deleting a user. We can't show the deletion screen anymore but I also wouldn't expect to see an error as the user hasn't done anything "wrong".