### PR TITLE
FHB-1421 removed alerts for the open_referral_mock_api_web_app and fh_idam_maintenance_ui app services

### DIFF
--- a/terraform/modules/fhinfrastructurestack/alerting.tf
+++ b/terraform/modules/fhinfrastructurestack/alerting.tf
@@ -42,17 +42,11 @@ locals {
     "fh_referral_api" = {
       app_service_id = azurerm_windows_web_app.fh_referral_api.id
     },
-    "open_referral_mock_api_web_app" = {
-      app_service_id = azurerm_windows_web_app.open_referral_mock_api_web_app.id
-    },
     "fh_notification_api" = {
       app_service_id = azurerm_windows_web_app.fh_notification_api.id
     },
     "fh_idam_api" = {
       app_service_id = azurerm_windows_web_app.fh_idam_api.id
-    },
-    "fh_idam_maintenance_ui" = {
-      app_service_id = azurerm_windows_web_app.fh_idam_maintenance_ui.id
     },
     "fh_referral_ui" = {
       app_service_id = azurerm_windows_web_app.fh_referral_ui.id


### PR DESCRIPTION
Removed alerts for the open_referral_mock_api_web_app and fh_idam_maintenance_ui app services after discussion with Dami, Aaron and Tina. They are usually switched off and the mock api is for internal testing.