### PR TITLE
FHB-1242 adf alerts - treat the Azure Data Factory component as optional

### DIFF
--- a/terraform/envs/test2/env.tfvars
+++ b/terraform/envs/test2/env.tfvars
@@ -39,3 +39,4 @@ private_endpoint_ip_address = {
 }
 
 pvt_endp_report_stg_api_ip_address = "10.0.3.109"
+data_factory_exists = false

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,4 +37,5 @@ module "fhinfrastructurestack" {
   find_domain = var.find_domain
   log_retention_in_days = var.log_retention_in_days
   pvt_endp_report_stg_api_ip_address = var.pvt_endp_report_stg_api_ip_address
+  data_factory_exists = var.data_factory_exists
 }

--- a/terraform/modules/fhinfrastructurestack/alerting.tf
+++ b/terraform/modules/fhinfrastructurestack/alerting.tf
@@ -4,8 +4,11 @@
 #
 ####################################################################################################
 
-# Azure data factory is managed outside of terraform
+# Azure data factory is managed outside of terraform and is an OPTIONAL environment component in
+# test environments
+
 data "azurerm_data_factory" "adf_dataf_default" {
+  count = var.data_factory_exists ? 1 : 0
   name = "${var.prefix}-dataf-default"
   resource_group_name = local.resource_group_name
 }
@@ -69,11 +72,11 @@ locals {
     }
   }
 
-  adf_details = {
+  adf_details = var.data_factory_exists ? {
     "fh_adf" = {
-      adf_id = data.azurerm_data_factory.adf_dataf_default.id
+      adf_id = data.azurerm_data_factory.adf_dataf_default[0].id
     }
-  }
+  } : {}
 }
 
 ####################################################################################################

--- a/terraform/modules/fhinfrastructurestack/vars.tf
+++ b/terraform/modules/fhinfrastructurestack/vars.tf
@@ -219,3 +219,9 @@ variable "service_principals" {
   })
   description = "Group and enterprise object Ids for service principals."
 }
+
+variable "data_factory_exists" {
+  type = bool
+  description = "Whether the data factory exists or not for the environment. It's optional for test environments."
+  default = true
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -219,3 +219,9 @@ variable "slack_support_channel_email" {
   type = string
   description = "The Slack channel email to send alerts to."
 }
+
+variable "data_factory_exists" {
+  type = bool
+  description = "Whether the data factory exists or not for the environment. It's optional for test environments."
+  default = true
+}


### PR DESCRIPTION
ADF doesn't exist for Test2 and may not exist for test environments in the future. Treat it as optional for alert creation.