### PR TITLE
ci(E2E): Fail on Failure

### DIFF
--- a/test/e2e-seed-data-framework/connections.js
+++ b/test/e2e-seed-data-framework/connections.js
@@ -37,6 +37,7 @@ export async function checkConnections() {
     await reportDb.authenticate();
   } catch (error) {
     console.error("Unable to establish connection to the database:", error);
+    process.exit(1);
   }
 
   console.log("Connections are OK!");
@@ -51,6 +52,7 @@ export async function closeConnections() {
     await reportDb.close();
   } catch (error) {
     console.error("Unable to close connection to the database:", error);
+    process.exit(1);
   }
 
   console.log("Connections Closed!");

--- a/test/e2e-seed-data-framework/scripts/setup.js
+++ b/test/e2e-seed-data-framework/scripts/setup.js
@@ -29,12 +29,16 @@ if (process.env.EXAMPLE_SEED.toUpperCase() === "TRUE") {
 
 await checkConnections();
 
+let succeeded = true;
+
 try {
   await setup();
 } catch (error) {
   console.error("Unable to run setup:", error);
+  succeeded = false;
 } finally {
   await closeConnections();
+  if (!succeeded) process.exit(1);
 }
 
 /**

--- a/test/e2e-seed-data-framework/scripts/teardown.js
+++ b/test/e2e-seed-data-framework/scripts/teardown.js
@@ -8,12 +8,16 @@ await checkConnections();
 
 const baseId = parseInt(process.env.IDS_START_FROM);
 
+let succeeded = true;
+
 try {
   await teardown();
 } catch (error) {
   console.error("Unable to run teardown:", error);
+  succeeded = false;
 } finally {
   await closeConnections();
+  if (!succeeded) process.exit(1);
 }
 
 async function teardown() {


### PR DESCRIPTION
We have an issue at the moment where Teardown & Setup E2E seed scripts are failing in Test & Pre-Prod, however they aren't exiting with code 1 or whatever (JS being JS?) so GitHub just sees them as "succeeding", gives them the green tick and carries on with running the E2E tests etc. This is not ideal.

This PR forces the E2E seed scripts to exit with a code 1 when they error, which in turn means the GitHub pipeline will show expected behaviour and fail.

Here's an example of the fix: https://github.com/DFE-Digital/fh-services/actions/runs/13356462748

And here is what it looks like without this fix: https://github.com/DFE-Digital/fh-services/actions/runs/13366485038/job/37325763082 if you expand "Run Teardown" you can see that it actually failed but JS sucks and doesn't let GitHub know.