### PR TITLE
[FHB-1250] Disable the request for support flag when vcfs flag is disabled

### DIFF
--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FeatureFlags/AlsoFilter.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FeatureFlags/AlsoFilter.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FeatureManagement;
+
+namespace FamilyHubs.SharedKernel.Razor.FeatureFlags;
+
+[FilterAlias(nameof(AlsoFilter))]
+public class AlsoFilter : IFeatureFilter
+{
+    private readonly Lazy<IFeatureManager> _featureManager;
+
+    public AlsoFilter(IServiceProvider serviceProvider)
+    {
+        _featureManager = new Lazy<IFeatureManager>(serviceProvider.GetRequiredService<IFeatureManager>);
+    }
+
+    public async Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+    {
+        var settings = context.Parameters.Get<AlsoFilterFilterSettings>();
+
+        var flags = settings?.Flags?.Split(",") ?? [];
+        var featureStates = flags.Select(flagName => _featureManager.Value.IsEnabledAsync(flagName)).ToArray();
+
+        return Array.Exists(
+            await Task.WhenAll(featureStates),
+            x => x
+        );
+    }
+
+    public class AlsoFilterFilterSettings
+    {
+        public string? Flags { get; init; }
+    }
+}

--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FeatureFlags/EnabledFilter.cs
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/FeatureFlags/EnabledFilter.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement;
+
+namespace FamilyHubs.SharedKernel.Razor.FeatureFlags;
+
+[FilterAlias(nameof(EnabledFilter))]
+public class EnabledFilter : IFeatureFilter
+{
+    public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+    {
+        var settings = context.Parameters.Get<EnabledFilterSettings>();
+        return Task.FromResult(settings?.Value == true);
+    }
+
+    public class EnabledFilterSettings
+    {
+        public bool Value { get; init; }
+    }
+}

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Program.cs
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Program.cs
@@ -1,4 +1,5 @@
 using FamilyHubs.SharedKernel.Extensions;
+using FamilyHubs.SharedKernel.Razor.FeatureFlags;
 using Microsoft.FeatureManagement;
 using Serilog;
 
@@ -24,8 +25,10 @@ public static class Program
 
             builder.ConfigureHost();
             
-            builder.Services.AddFeatureManagement(builder.Configuration.GetSection("FeatureManagement"));
-            
+            builder.Services.AddFeatureManagement(builder.Configuration)
+                .AddFeatureFilter<AlsoFilter>()
+                .AddFeatureFilter<EnabledFilter>();
+
             builder.Services.ConfigureServices(builder.Configuration);
 
             var app = builder.Build();

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/appsettings.json
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/appsettings.json
@@ -147,7 +147,32 @@
     }
   },
   "FeatureManagement": {
-    "ConnectDashboard": true,
-    "VcfsServices": true
+    "ConnectDashboard": {
+      "RequirementType": "All",
+      "EnabledFor": [
+        {
+          "Name": "EnabledFilter",
+          "Parameters": {
+            "Value": true
+          }
+        },
+        {
+          "Name": "AlsoFilter",
+          "Parameters": {
+            "Flags": "VcfsServices"
+          }
+        }
+      ]
+    },
+    "VcfsServices": {
+      "EnabledFor": [
+        {
+          "Name": "EnabledFilter",
+          "Parameters": {
+            "Value": true
+          }
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
Add feature filters to conditionally apply dashboard filter. Also added a dummy filter to allow us to maintain easy on/off switching.

This will require changing the configuration names in key vault:

> CONNECT-UI-FeatureManagement--ConnectDashboard
> CONNECT-UI-FeatureManagement--ConnectDashboard--EnabledFor--0--Parameters--Value

> CONNECT-UI-FeatureManagement--VcfsServices
> CONNECT-UI-FeatureManagement--VcfsServices--EnabledFor--0--Parameters--Value