### PR TITLE
ci(Stryker): FHB-875 - Stryker Mutator Weekly Report

### DIFF
--- a/.github/actions/run-dotnet-stryker/action.yml
+++ b/.github/actions/run-dotnet-stryker/action.yml
@@ -1,0 +1,47 @@
+name: Run DotNet Stryker
+description: Runs DotNet Stryker Mutations Testing against a solution and publishes the results to the workflow
+
+inputs:
+  working_directory:
+    description: The working directory which contains the Solution to be ran against
+    required: true
+  config_path:
+    description: The Stryker configuration file path
+    required: true
+  artifact:
+    description: The artifact to upload to the Workflow results
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Stryker Mutator
+      shell: bash
+      run: dotnet tool install --global dotnet-stryker
+
+    - name: Warm-Up Build
+      # TODO: Probably not needed but using to diagnose instabilities
+      shell: bash
+      run: |
+        cd ${{ inputs.working_directory }}
+        dotnet restore
+        dotnet build --no-restore
+        
+    - name: Run Stryker Mutator
+      shell: bash
+      run: |
+        cd ${{ inputs.working_directory }}
+        dotnet stryker -f ${{ inputs.config_path }} -O StrykerOutput --concurrency `nproc`
+      
+    - name: Generate Stryker Report
+      shell: bash
+      run: |
+        echo '### ${{ inputs.artifact }} 🚀' >> $GITHUB_STEP_SUMMARY
+        cat ${{ inputs.working_directory }}/StrykerOutput/reports/mutation-report.md >> $GITHUB_STEP_SUMMARY
+
+    - name: Upload HTML Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact }}
+        path: ${{ inputs.working_directory }}/StrykerOutput/reports/mutation-report.html
+        compression-level: '9'

--- a/.github/actions/run-dotnet-stryker/action.yml
+++ b/.github/actions/run-dotnet-stryker/action.yml
@@ -1,9 +1,9 @@
 name: Run DotNet Stryker
-description: Runs DotNet Stryker Mutations Testing against a solution and publishes the results to the workflow
+description: Runs DotNet Stryker Mutations Testing against a solution or project and publishes the results to the workflow
 
 inputs:
   working_directory:
-    description: The working directory which contains the Solution to be ran against
+    description: The working directory which contains the Solution/Project to be ran against
     required: true
   config_path:
     description: The Stryker configuration file path
@@ -18,9 +18,8 @@ runs:
     - name: Install Stryker Mutator
       shell: bash
       run: dotnet tool install --global dotnet-stryker
-
-    - name: Warm-Up Build
-      # TODO: Probably not needed but using to diagnose instabilities
+      
+    - name: Build Project
       shell: bash
       run: |
         cd ${{ inputs.working_directory }}
@@ -31,7 +30,7 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.working_directory }}
-        dotnet stryker -f ${{ inputs.config_path }} -O StrykerOutput --concurrency `nproc`
+        dotnet stryker -f ${{ inputs.config_path }} -O StrykerOutput --skip-version-check --concurrency `nproc`
       
     - name: Generate Stryker Report
       shell: bash
@@ -42,6 +41,6 @@ runs:
     - name: Upload HTML Report
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.artifact }}
+        name: Stryker - ${{ inputs.artifact }} - HTML Report
         path: ${{ inputs.working_directory }}/StrykerOutput/reports/mutation-report.html
         compression-level: '9'

--- a/.github/actions/run-dotnet-stryker/stryker-config.json
+++ b/.github/actions/run-dotnet-stryker/stryker-config.json
@@ -1,6 +1,11 @@
 {
   "stryker-config": {
     "reporters": ["progress", "markdown", "html"],
-    "mutate": ["!**/Migrations/*.cs", "!**/acceptance-tests/*.cs"]
+    "mutate": [
+      "!**/*Program.cs", "!**/*StartupExtensions.cs",
+      "!**/Migrations/*.cs",
+      "!**/*ApplicationDbContext.cs", "!**/*ReportDbContext.cs", "!**/*FunctionDbContext.cs",
+      "!**/*ReferralSeedData.cs", "!**/*OrganisationSeedData.cs"
+    ]
   }
 }

--- a/.github/actions/run-dotnet-stryker/stryker-config.json
+++ b/.github/actions/run-dotnet-stryker/stryker-config.json
@@ -1,0 +1,6 @@
+{
+  "stryker-config": {
+    "reporters": ["progress", "markdown", "html"],
+    "mutate": ["!**/Migrations/*.cs", "!**/acceptance-tests/*.cs"]
+  }
+}

--- a/.github/workflows/stryker-full-report.yml
+++ b/.github/workflows/stryker-full-report.yml
@@ -1,0 +1,88 @@
+name: Stryker Mutator (Full Report)
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Midnight every Monday
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  stryker-matrix:
+    name: Stryker - ${{ matrix.job_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        working_directory:
+          [
+            service/notification-api,
+            service/idam-api,
+            service/service-directory-api,
+            service/referral-api,
+            service/report-api,
+            function/open-referral-function,
+            ui/connect-ui,
+            ui/find-ui,
+            ui/idam-maintenance-ui,
+            ui/manage-ui,
+            shared/referral-shared,
+            shared/service-directory-shared,
+            shared/shared-kernel,
+            shared/web-components
+          ]
+        include:
+          - working_directory: service/notification-api
+            job_name: "Notification API"
+          - working_directory: service/idam-api
+            job_name: "IdAM API"
+          - working_directory: service/service-directory-api
+            job_name: "Service Directory API"
+          - working_directory: service/referral-api
+            job_name: "Referral API"
+          - working_directory: service/report-api
+            job_name: "Report API"
+          - working_directory: function/open-referral-function
+            job_name: "Open Referral Function"
+          - working_directory: ui/connect-ui
+            job_name: "Connect UI"
+          - working_directory: ui/find-ui
+            job_name: "Find UI"
+          - working_directory: ui/idam-maintenance-ui
+            job_name: "IDAM Maintenance UI"
+          - working_directory: ui/manage-ui
+            job_name: "Manage UI"
+          - working_directory: shared/referral-shared
+            job_name: "Referral Shared"
+          - working_directory: shared/service-directory-shared
+            job_name: "Service Directory Shared"
+          - working_directory: shared/shared-kernel
+            job_name: "Kernel Shared"
+          - working_directory: shared/web-components
+            job_name: "Web Components Shared"      
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup .NET ${{ vars.DOTNET_VERSION_V8 }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ vars.DOTNET_VERSION_V8 }}
+
+      - name: Install & Configure SpatiaLite
+        if: ${{ matrix.job_name == 'Service Directory API' || matrix.job_name == 'Referral API' }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install libspatialite-dev libsqlite3-mod-spatialite -y
+          sudo ldconfig "/usr/lib/x86_64-linux-gnu/mod_spatialite.so"
+
+      - name: Run Stryker Mutator
+        uses: ./.github/actions/run-dotnet-stryker
+        with:
+          working_directory: ${{ github.workspace }}/src/${{ matrix.working_directory }}
+          config_path: ${{ github.workspace }}/.github/actions/run-dotnet-stryker/stryker-config.json
+          artifact: ${{ matrix.job_name }}

--- a/.github/workflows/stryker-full-report.yml
+++ b/.github/workflows/stryker-full-report.yml
@@ -1,7 +1,7 @@
 name: Stryker Mutator (Full Report)
 on:
   schedule:
-    - cron: "0 0 * * 1" # Midnight every Monday
+    - cron: "0 0 * * 1" # 12:00 AM every Monday
   workflow_dispatch:
 
 concurrency:
@@ -49,7 +49,7 @@ jobs:
           - working_directory: ui/find-ui
             job_name: "Find UI"
           - working_directory: ui/idam-maintenance-ui
-            job_name: "IDAM Maintenance UI"
+            job_name: "IdAM Maintenance UI"
           - working_directory: ui/manage-ui
             job_name: "Manage UI"
           - working_directory: shared/referral-shared
@@ -66,11 +66,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          fetch-depth: '0'
 
       - name: Setup .NET ${{ vars.DOTNET_VERSION_V8 }}
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ vars.DOTNET_VERSION_V8 }}
+          
+      - name: NuGet Package Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-NuGet-${{ matrix.job_name }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-NuGet-${{ matrix.job_name }}-${{ hashFiles('**/*.csproj') }}
 
       - name: Install & Configure SpatiaLite
         if: ${{ matrix.job_name == 'Service Directory API' || matrix.job_name == 'Referral API' }}
@@ -86,3 +95,17 @@ jobs:
           working_directory: ${{ github.workspace }}/src/${{ matrix.working_directory }}
           config_path: ${{ github.workspace }}/.github/actions/run-dotnet-stryker/stryker-config.json
           artifact: ${{ matrix.job_name }}
+  
+  merge-html-reports:
+    needs: [ stryker-matrix ]
+    if: always()
+    name: "Merge HTML Reports"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Merge HTML Reports"
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: 'Stryker - Full HTML Report'
+          separate-directories: true
+          delete-merged: true
+          compression-level: '9'

--- a/src/service/referral-api/tests/FamilyHubs.ReferralApi.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/src/service/referral-api/tests/FamilyHubs.ReferralApi.FunctionalTests/CustomWebApplicationFactory.cs
@@ -20,7 +20,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
     {
         _conf = conf;
         _sdClient = sdClient;
-        _referralConnection = $"Data Source=sd-{Random.Shared.Next().ToString()}.db;Mode=ReadWriteCreate;Cache=Shared;Foreign Keys=True;Recursive Triggers=True;Default Timeout=30;Pooling=True";
+        _referralConnection = $"Data Source=REFERRAL-{Guid.NewGuid()}.db;Mode=ReadWriteCreate;Cache=Shared;Foreign Keys=True;Recursive Triggers=True;Default Timeout=30;Pooling=True";
     }
 
     /// <summary>

--- a/src/service/referral-api/tests/FamilyHubs.ReferralApi.FunctionalTests/ServiceDirectoryFactory.cs
+++ b/src/service/referral-api/tests/FamilyHubs.ReferralApi.FunctionalTests/ServiceDirectoryFactory.cs
@@ -13,7 +13,7 @@ namespace FamilyHubs.Referral.FunctionalTests;
 
 public class ServiceDirectoryFactory : WebApplicationFactory<Program>
 {
-    private readonly string _sdConnection = $"Data Source=sd-{Random.Shared.Next().ToString()}.db;Mode=ReadWriteCreate;Cache=Shared;Foreign Keys=True;Recursive Triggers=True;Default Timeout=30;Pooling=True";
+    private readonly string _sdConnection = $"Data Source=SERVICE_DIRECTORY-{Guid.NewGuid()}.db;Mode=ReadWriteCreate;Cache=Shared;Foreign Keys=True;Recursive Triggers=True;Default Timeout=30;Pooling=True";
 
     protected override IHost CreateHost(IHostBuilder builder)
     {

--- a/src/service/referral-api/tests/FamilyHubs.ReferralApi.FunctionalTests/WhenUsingReferralsApiUnitTests.cs
+++ b/src/service/referral-api/tests/FamilyHubs.ReferralApi.FunctionalTests/WhenUsingReferralsApiUnitTests.cs
@@ -13,10 +13,6 @@ namespace FamilyHubs.Referral.FunctionalTests;
 [Collection("Sequential")]
 public class WhenUsingReferralsApiUnitTests : BaseWhenUsingOpenReferralApiUnitTests
 {
-#if UseJsonService
-    const string JsonService = "{\"Id\":\"ba1cca90-b02a-4a0b-afa0-d8aed1083c0d\",\"Name\":\"Test County Council\",\"Description\":\"Test County Council\",\"Logo\":null,\"Uri\":\"https://www.test.gov.uk/\",\"Url\":\"https://www.test.gov.uk/\",\"Services\":[{\"Id\":\"c1b5dd80-7506-4424-9711-fe175fa13eb8\",\"Name\":\"Test Organisation for Children with Tracheostomies\",\"Description\":\"Test Organisation for for Children with Tracheostomies is a national self help group operating as a registered charity and is run by parents of children with a tracheostomy and by people who sympathise with the needs of such families. ACT as an organisation is non profit making, it links groups and individual members throughout Great Britain and Northern Ireland.\",\"Accreditations\":null,\"Assured_date\":null,\"Attending_access\":null,\"Attending_type\":null,\"Deliverable_type\":null,\"Status\":\"active\",\"Url\":\"www.testservice.com\",\"Email\":\"support@testservice.com\",\"Fees\":null,\"ServiceDelivery\":[{\"Id\":\"14db2aef-9292-4afc-be09-5f6f43765938\",\"ServiceDelivery\":2}],\"Eligibilities\":[{\"Id\":\"Test9109Children\",\"Eligibility\":\"\",\"Maximum_age\":0,\"Minimum_age\":13}],\"Contacts\":[{\"Id\":\"5eac5cb6-cc7e-444d-a29b-76ccb85be866\",\"Title\":\"Service\",\"Name\":\"\",\"Phones\":[{\"Id\":\"1568\",\"Number\":\"01827 65779\"}]}],\"Cost_options\":[],\"Languages\":[{\"Id\":\"442a06cd-aa14-4ea3-9f11-b45c1bc4861f\",\"Language\":\"English\"}],\"Service_areas\":[{\"Id\":\"68af19cd-bc81-4585-99a2-85a2b0d62a1d\",\"Service_area\":\"National\",\"Extent\":null,\"Uri\":\"http://statistics.data.gov.uk/id/statistical-geography/K02000001\"}],\"Service_at_locations\":[{\"Id\":\"Test1749\",\"Location\":{\"Id\":\"a878aadc-6097-4a0f-b3e1-77fd4511175d\",\"Name\":\"\",\"Description\":\"\",\"Latitude\":52.6312,\"Longitude\":-1.66526,\"Physical_addresses\":[{\"Id\":\"1076aaa8-f99d-4395-8e4f-c0dde8095085\",\"Address_1\":\"75 Sheepcote Lane\",\"City\":\", Stathe, Tamworth, Staffordshire, \",\"Postal_code\":\"B77 3JN\",\"Country\":\"England\",\"State_province\":null}]}}],\"Service_taxonomys\":[{\"Id\":\"Test9107\",\"Taxonomy\":{\"Id\":\"Test bccsource:Organisation\",\"Name\":\"Organisation\",\"Vocabulary\":\"Test BCC Data Sources\",\"Parent\":null}},{\"Id\":\"Test9108\",\"Taxonomy\":{\"Id\":\"Test bccprimaryservicetype:38\",\"Name\":\"Support\",\"Vocabulary\":\"Test BCC Primary Services\",\"Parent\":null}},{\"Id\":\"Test9109\",\"Taxonomy\":{\"Id\":\"Test bccagegroup:37\",\"Name\":\"Children\",\"Vocabulary\":\"Test BCC Age Groups\",\"Parent\":null}},{\"Id\":\"Test9110\",\"Taxonomy\":{\"Id\":\"Testbccusergroup:56\",\"Name\":\"Long Term Health Conditions\",\"Vocabulary\":\"Test BCC User Groups\",\"Parent\":null}}]}]}";
-#endif
-
     [Fact]
     public async Task ThenReferralsByReferrerAreRetrieved()
     {
@@ -151,7 +147,7 @@ public class WhenUsingReferralsApiUnitTests : BaseWhenUsingOpenReferralApiUnitTe
             RequestUri = new Uri(Client.BaseAddress + "api/organisationreferrals/1?pageNumber=1&pageSize=10"),
         };
 
-        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(Vcstoken)}");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(VcsToken)}");
 
         using var response = await Client.SendAsync(request);
 
@@ -174,7 +170,7 @@ public class WhenUsingReferralsApiUnitTests : BaseWhenUsingOpenReferralApiUnitTe
             RequestUri = new Uri(Client.BaseAddress + "api/referral/1"),
         };
 
-        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(TokenForOrganisation1)}");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(TokenForOrganisationOne)}");
 
         using var response = await Client.SendAsync(request);
 
@@ -196,7 +192,7 @@ public class WhenUsingReferralsApiUnitTests : BaseWhenUsingOpenReferralApiUnitTe
             RequestUri = new Uri(Client.BaseAddress + "api/referral/1"),
         };
 
-        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(Vcstoken)}");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(VcsToken)}");
 
         using var response = await Client.SendAsync(request);
 
@@ -218,7 +214,7 @@ public class WhenUsingReferralsApiUnitTests : BaseWhenUsingOpenReferralApiUnitTe
             RequestUri = new Uri(Client.BaseAddress + "api/referral/1"),
         };
 
-        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(Forbiddentoken)}");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(ForbiddenToken)}");
 
         using var response = await Client.SendAsync(request);
 
@@ -304,7 +300,7 @@ public class WhenUsingReferralsApiUnitTests : BaseWhenUsingOpenReferralApiUnitTe
             RequestUri = new Uri(Client.BaseAddress + "api/status/1/Accepted")
         };
 
-        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(Vcstoken)}");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(VcsToken)}");
 
         using var response = await Client.SendAsync(request);
 
@@ -326,7 +322,7 @@ public class WhenUsingReferralsApiUnitTests : BaseWhenUsingOpenReferralApiUnitTe
             RequestUri = new Uri(Client.BaseAddress + "api/status/1/Declined/Unable to help")
         };
 
-        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(Vcstoken)}");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue($"Bearer", $"{new JwtSecurityTokenHandler().WriteToken(VcsToken)}");
 
         using var response = await Client.SendAsync(request);
 

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/VcsAdmin/Pages/ManageOrganisations.cshtml.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/VcsAdmin/Pages/ManageOrganisations.cshtml.cs
@@ -1,13 +1,13 @@
 using System.Text;
 using FamilyHubs.ServiceDirectory.Admin.Core.ApiClient;
 using FamilyHubs.ServiceDirectory.Admin.Core.Services;
+using FamilyHubs.ServiceDirectory.Admin.Web.Components;
 using FamilyHubs.ServiceDirectory.Admin.Web.Pages.Shared;
 using FamilyHubs.ServiceDirectory.Shared.Dto;
 using FamilyHubs.ServiceDirectory.Shared.Models;
 using FamilyHubs.SharedKernel.Identity;
 using FamilyHubs.SharedKernel.Razor.Pagination;
 using Microsoft.AspNetCore.Mvc;
-using static FamilyHubs.ServiceDirectory.Admin.Web.Components.SortHeaderComponent;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Areas.VcsAdmin.Pages
 {

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Components/SortHeaderComponent.razor
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Components/SortHeaderComponent.razor
@@ -57,11 +57,4 @@
                 return $"{Name}_{SortOrder.Descending.ToString()}";
         }
     }
-
-    public enum SortOrder
-    {
-        Ascending,
-        Descending,
-        None
-    }
 }

--- a/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Components/SortOrder.cs
+++ b/src/ui/manage-ui/src/FamilyHubs.ServiceDirectory.Admin.Web/Components/SortOrder.cs
@@ -1,0 +1,8 @@
+﻿namespace FamilyHubs.ServiceDirectory.Admin.Web.Components;
+
+public enum SortOrder
+{
+    Ascending,
+    Descending,
+    None
+}


### PR DESCRIPTION
Ticket: [FHB-875](https://dfedigital.atlassian.net.mcas.ms/browse/FHB-875)

Currently some config is default. For example the high/low/break at thresholds (80/60/0). This is because the scores are pretty dire at the moment and so we will need to analyse these and determine what values suit us later. This will influence the PR gating ticket also.

Example: https://github.com/DFE-Digital/fh-services/actions/runs/13509189310

---

This PR:

- Creates a new workflow to run DotNet Stryker on a weekly schedule against each project. It can also be ran manually in the Actions tab on GitHub.

- Bundles the critical section (i.e., running Stryker itself) into a reusable Action. This makes things a bit tidier but also can be reused for the ticket to implement Stryker PR gating. 

- Uses a central config file. This will make it easier to add/remove options as we decide on exclusions, high/low/break thresholds, etc. Imagine if all those were command line args!

- Outputs a per-project summary into the GitHub Workflow Summary for quick success/fail viewing.

- Also creates a downloadable HTML artifact for deeper analysis. This shows what Stryker does to each line of code and what tests, if any, were killed, survived, timed out, etc as a result.

- Merges each HTML report into a single downloadable artifact. Each project has its own folder in the artifact.

- Fixes the Referral API functional tests not clearing down their SQLite database files, which lead to disk space errors.

- Also just does a tiny bit of cleanup in that area, such as renaming some variables and removing a useless blob of JSON.

[FHB-875]: https://dfedigital.atlassian.net/browse/FHB-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ