### PR TITLE
refactor(Connect): FHB-1335 - None Provided Default

### DIFF
--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/LocalOfferDetail.cshtml
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/LocalOfferDetail.cshtml
@@ -119,7 +119,7 @@
                         @ByDayToDisplay(serviceAtLocationSchedule?.ByDay)
                     </summary-row>
 
-                    <summary-row key="Extra availability details"  class="fh-pre-wrap">@serviceAtLocationSchedule?.Description</summary-row>
+                    <summary-row key="Extra availability details"  class="fh-pre-wrap">@serviceAtLocationSchedule?.Description.GetDisplay()</summary-row>
 
                 </summary-list>
             }
@@ -133,7 +133,7 @@
                 <summary-row key="Days service is available">
                     @ByDayToDisplay(Model.ServiceSchedule.ByDay)
                 </summary-row>
-                <summary-row key="Extra availability details"  class="fh-pre-wrap">@Model.ServiceSchedule.Description</summary-row>
+                <summary-row key="Extra availability details"  class="fh-pre-wrap">@(Model.ServiceSchedule.Description.GetDisplay())</summary-row>
             </summary-list>
         }
 


### PR DESCRIPTION
Ticket: [FHB-1335](https://dfedigital.atlassian.net/browse/FHB-1335)

---

This PR:

- Defaults to the string "None provided" on the "Extra availability details" sections of locations and other schedules (online and/or telephone) if no details were provided when adding the service.

[FHB-1335]: https://dfedigital.atlassian.net/browse/FHB-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ