### PR TITLE
FHB-1351 Pin terraform version to 4.19.0 and fix deprecation warnings

### DIFF
--- a/terraform/modules/fhinfrastructurestack/main.tf
+++ b/terraform/modules/fhinfrastructurestack/main.tf
@@ -2584,7 +2584,7 @@ resource "azurerm_storage_account" "storage_appgw_errorpage" {
 
 resource "azurerm_storage_container" "container_appgw_referral_ui" {
   name                  				= "${var.prefix}sacontappgwrefui"
-  storage_account_name  				= azurerm_storage_account.storage_appgw_errorpage.name
+  storage_account_id  				= azurerm_storage_account.storage_appgw_errorpage.id
   container_access_type 				= "blob"
 }
 
@@ -2610,7 +2610,7 @@ resource "azurerm_storage_blob" "blob_appgw_referral_ui_error403" {
 
 resource "azurerm_storage_container" "container_appgw_sd_admin_ui" {
   name                  				= "${var.prefix}sacontappgwsdadminui"
-  storage_account_name  				= azurerm_storage_account.storage_appgw_errorpage.name
+  storage_account_id  				= azurerm_storage_account.storage_appgw_errorpage.id
   container_access_type 				= "blob"
 }
 
@@ -2636,7 +2636,7 @@ resource "azurerm_storage_blob" "blob_appgw_sd_admin_ui_error403" {
 
 resource "azurerm_storage_container" "container_appgw_sd_ui" {
   name                  				= "${var.prefix}sacontappgwsdui"
-  storage_account_name  				= azurerm_storage_account.storage_appgw_errorpage.name
+  storage_account_id  				= azurerm_storage_account.storage_appgw_errorpage.id
   container_access_type 				= "blob"
 }
 
@@ -2682,7 +2682,7 @@ resource "azurerm_storage_account" "storage_db_logs" {
 
 resource "azurerm_storage_container" "container_db_va_logs" {
   name                  = "${var.prefix}sadbvalogs"
-  storage_account_name  = azurerm_storage_account.storage_db_logs.name
+  storage_account_id  = azurerm_storage_account.storage_db_logs.id
   container_access_type = "blob"
 }
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = ">= 4.10.0"
+      version = "= 4.19.0"
     }
   }
 }


### PR DESCRIPTION
Version pinning plus deprecation warning fix. Fixing the deprecations means the storage account blobs for the custom error pages are recreated in place. Terraform may fail the first time with this, but the second provisioning run will work.