### PR TITLE
refactor(Playwright): Basic Auth for Single Directory

### DIFF
--- a/test/find-e2e-tests/.gitignore
+++ b/test/find-e2e-tests/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 /target
+.env
+/playwright/.auth/

--- a/test/find-e2e-tests/playwright.config.ts
+++ b/test/find-e2e-tests/playwright.config.ts
@@ -70,7 +70,6 @@ export default defineConfig<SerenityOptions>({
             name: 'Chromium',
             use: {
                 ...devices['Desktop Chrome'],
-                storageState: 'playwright/.auth/user.json'
             },
             dependencies: ['setup']
         },
@@ -82,7 +81,6 @@ export default defineConfig<SerenityOptions>({
             use: {
                 ...devices['Desktop Firefox'],
                 ignoreHTTPSErrors: true,
-                storageState: 'playwright/.auth/user.json'
             },
             dependencies: ['setup']
         },
@@ -91,7 +89,6 @@ export default defineConfig<SerenityOptions>({
             use: {
                 ...devices['Desktop Safari'],
                 ignoreHTTPSErrors: true,
-                storageState: 'playwright/.auth/user.json'
             },
             dependencies: ['setup']
         }

--- a/test/find-e2e-tests/playwright.config.ts
+++ b/test/find-e2e-tests/playwright.config.ts
@@ -7,7 +7,7 @@ dotenv.config();
 export default defineConfig<SerenityOptions>({
     testDir: './tests',
     /* Maximum time one test can run for, measured in milliseconds. */
-    timeout: 30_000,
+    timeout: 40_000,
     expect: {
         /**
          * The maximum time, in milliseconds, that expect() should wait for a condition to be met.
@@ -54,18 +54,27 @@ export default defineConfig<SerenityOptions>({
         trace: 'on-first-retry',
 
         // Capture screenshot only on failure
-        screenshot: 'only-on-failure'
+        screenshot: 'only-on-failure',
+
+        httpCredentials: {
+            username: process.env.USER_NAME,
+            password: process.env.PASSWORD,
+        }
     },
 
     /* Configure projects for major browsers */
     projects: [
+        { name: 'setup', testMatch: /.*\.setup\.ts/ },
+
         {
             name: 'Chromium',
             use: {
                 ...devices['Desktop Chrome'],
-            }
+                storageState: 'playwright/.auth/user.json'
+            },
+            dependencies: ['setup']
         },
-        
+
         // Firefox & Safari have a temporary workaround to ignore HTTPS errors due to a bug around TLS certificates.
         // Jira Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/FHB-1180
         {
@@ -73,14 +82,18 @@ export default defineConfig<SerenityOptions>({
             use: {
                 ...devices['Desktop Firefox'],
                 ignoreHTTPSErrors: true,
+                storageState: 'playwright/.auth/user.json'
             },
+            dependencies: ['setup']
         },
         {
             name: 'Safari',
             use: {
                 ...devices['Desktop Safari'],
                 ignoreHTTPSErrors: true,
+                storageState: 'playwright/.auth/user.json'
             },
+            dependencies: ['setup']
         }
         //TODO: Get tests running on mobile safari/chrome - need some custom code to scroll elements into view.
         // {

--- a/test/find-e2e-tests/tests/auth.setup.ts
+++ b/test/find-e2e-tests/tests/auth.setup.ts
@@ -1,0 +1,13 @@
+import { test as setup } from '@playwright/test';
+import path from 'path';
+import {isTheFindPageDisplayed} from "./serenity-tools/find-questions";
+
+const authFile = path.join(__dirname, '../playwright/.auth/user.json');
+
+setup('Perform Basic Auth', async ({ page }) => {
+
+    await page.goto(process.env.BASE_URL);
+    isTheFindPageDisplayed()
+
+    await page.context().storageState({ path: authFile });
+});

--- a/test/find-e2e-tests/tests/auth.setup.ts
+++ b/test/find-e2e-tests/tests/auth.setup.ts
@@ -1,13 +1,7 @@
 import { test as setup } from '@playwright/test';
-import path from 'path';
 import {isTheFindPageDisplayed} from "./serenity-tools/find-questions";
 
-const authFile = path.join(__dirname, '../playwright/.auth/user.json');
-
 setup('Perform Basic Auth', async ({ page }) => {
-
     await page.goto(process.env.BASE_URL);
     isTheFindPageDisplayed()
-
-    await page.context().storageState({ path: authFile });
 });

--- a/test/find-e2e-tests/tests/serenity-tools/find-questions.ts
+++ b/test/find-e2e-tests/tests/serenity-tools/find-questions.ts
@@ -1,10 +1,7 @@
 import { Page } from '@serenity-js/web';
-import { Ensure, equals } from '@serenity-js/assertions';
+import {Ensure, equals, includes} from '@serenity-js/assertions';
 
 //This is for illustrative purposes and will be removed when appropriate questions can be created. 
 
 export const isTheFindPageDisplayed = () =>
-    Ensure.that(
-        Page.current().title().describedAs('Find Page Title'),
-        equals('Find support for your family - Find support for your family - GOV.UK'),
-    )  
+    Ensure.that(Page.current().url().toString(), includes(process.env.BASE_URL));


### PR DESCRIPTION
Ticket: [FHB-1295](https://dfedigital.atlassian.net/browse/FHB-1295)

---

This PR:

- Adds basic auth login / session storage for the Single Directory. Should login make its return it's also set up to automatically work.

Workflow: https://github.com/DFE-Digital/fh-services/actions/runs/13569301824

As seen here Find is able to run its tests against Dev which currently has the basic auth gate enabled. The Manage tests are also executing meaning they are also continuing to work without modification.

[FHB-1295]: https://dfedigital.atlassian.net/browse/FHB-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ