### PR TITLE
FHB-1174-Adding-Testdata-id-tag-for-services

### DIFF
--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/LocalOfferResultsPartialViews/_ResultsSection.cshtml
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/LocalOfferResultsPartialViews/_ResultsSection.cshtml
@@ -5,7 +5,7 @@
     {
         var eligibility = item.Eligibilities.FirstOrDefault();
 
-        <li tab-index="0">
+        <li tab-index="0" data-testid="@($"service-area-{item.Name.ToLower().Replace(" ", "")}")">
             <h2 class="govuk-heading-s govuk-!-margin-bottom-3">
                 <a class="govuk-link" asp-page="/ProfessionalReferral/LocalOfferDetail" asp-route-serviceid="@item.Id"
                    data-testid=@item.Name.ToLower().Replace(" ", "")>@item.Name</a><span class="govuk-!-font-weight-regular">@item.DistanceText</span>

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/LocalOfferResultsPartialViews/_ResultsSection.cshtml
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/LocalOfferResultsPartialViews/_ResultsSection.cshtml
@@ -4,11 +4,12 @@
     @foreach (var item in Model.SearchResults.Items)
     {
         var eligibility = item.Eligibilities.FirstOrDefault();
+        var serviceNameTestId = @item.Name.ToLower().Replace(" ", "");
 
-        <li tab-index="0" data-testid="@($"service-area-{item.Name.ToLower().Replace(" ", "")}")">
+         <li tab-index="0" data-testid="@($"service-area-{serviceNameTestId}")">
             <h2 class="govuk-heading-s govuk-!-margin-bottom-3">
                 <a class="govuk-link" asp-page="/ProfessionalReferral/LocalOfferDetail" asp-route-serviceid="@item.Id"
-                   data-testid=@item.Name.ToLower().Replace(" ", "")>@item.Name</a><span class="govuk-!-font-weight-regular">@item.DistanceText</span>
+                  data-testid="@serviceNameTestId">@item.Name</a><span class="govuk-!-font-weight-regular">@item.DistanceText</span>
             </h2>
             @if (!string.IsNullOrWhiteSpace(item.OrganisationName))
             {


### PR DESCRIPTION
## Description

Adding test data id tag for services within the service search page to help automated tests.
![Screenshot 2025-03-05 at 20 03 22](https://github.com/user-attachments/assets/9281b28b-1b8b-42d2-98b7-c05199add689)



