### PR TITLE
refactor(Connect): FHB-1433 - Home Page Title

### DIFF
--- a/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Pages/Shared/_Head.cshtml
+++ b/src/shared/web-components/src/FamilyHubs.SharedKernel.Razor/Pages/Shared/_Head.cshtml
@@ -1,13 +1,21 @@
 ﻿@model FamilyHubs.SharedKernel.Razor.FamilyHubsUi.FamilyHubsLayoutModel
 @{
     var familyHubsUiOptions = Model.FamilyHubsUiOptions.Value;
+    
+    string? tabTitle;
+    string? relativePath = Context.Request.Path.Value;
+    
+    if (relativePath is not null && relativePath.Equals("/")) tabTitle = $"{ViewData["Title"]}";
+    else tabTitle = $"{ViewData["Title"]} - {familyHubsUiOptions.ServiceName} - GOV.UK";
+    
+    if (Model.IsError) tabTitle = "Error: " + tabTitle;
 }
 
 <partial name="_GoogleAnalytics.cshtml" model="familyHubsUiOptions"/>
 <partial name="_MicrosoftClarity.cshtml" model="familyHubsUiOptions"/>
 
 <meta charset="utf-8" />
-<title>@if (Model.IsError) { <text>Error: </text> }@ViewData["Title"] - @familyHubsUiOptions.ServiceName - GOV.UK</title>
+<title>@tabTitle</title>
 <meta name="description" content="@familyHubsUiOptions.ServiceName">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="theme-color" content="#0b0c0c">

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/Index.cshtml
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/Index.cshtml
@@ -1,12 +1,13 @@
 ﻿@page
 @model FamilyHubs.Referral.Web.Pages.IndexModel
 @{
-    ViewData["Title"] = "Find support for parents, carers and young people";
+    const string pageTitle = "Find support for parents, carers and young people";
+    ViewData["Title"] = pageTitle;
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-4 govuk-!-margin-top-2">Find support for parents, carers and young people</h1>
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-4 govuk-!-margin-top-2">@pageTitle</h1>
         
         <p>This website is for parents, carers, young people and families, or those supporting them.</p>
         <p>Search for services and support such as:</p>

--- a/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/Index.cshtml
+++ b/src/ui/connect-ui/src/FamilyHubs.Referral.Web/Pages/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿@page
 @model FamilyHubs.Referral.Web.Pages.IndexModel
 @{
-    ViewData["Title"] = "Connect families to support";
+    ViewData["Title"] = "Find support for parents, carers and young people";
 }
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## Description

This PR...

- Adds a special case for the home page of a site to have its name in the tab just once by matching the H1 tag.
- This changes the home page tab of Connect from `Find support for parents, carers and young people - Find support for parents, carers and young people - GOV.UK` to just `Find support for parents, carers and young people`
- Also bonus fixes Manage, which used to say `Manage family support services and accounts - Manage family support services and accounts - GOV.UK` to just say `Manage family support services and accounts`.
- Other pages still retain the old pattern as expected. E.g., `Search for services by postcode - Find support for parents, carers and young people - GOV.UK`

Ticket: [FHB-1433](https://dfedigital.atlassian.net.mcas.ms/browse/FHB-1433)

## Checklist

- [x] Jira ticket ID included in the title (unless not applicable)
- [x] Short, descriptive and sentence-case title used briefly describing the change
- [x] Commit messages are short, informative and accurate. When in doubt, use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] ~~Documentation related to the change has been added/updated as appropriate~~
- [x] Changes have been given a once-over for spelling and grammar errors
- [ ] ~~Tests have been added to cover any changes~~


[FHB-1433]: https://dfedigital.atlassian.net/browse/FHB-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ