### PR TITLE
FHB-1437 Remove dashboard UI from monitoring dashboard and change alerting resource group

### DIFF
--- a/terraform/files/dashboard/template.json
+++ b/terraform/files/dashboard/template.json
@@ -17,7 +17,6 @@
           "/subscriptions/56c128b8-5ca9-4328-bb24-a11c829f4af9/resourceGroups/s181d01-familyhubs/providers/Microsoft.Web/sites/s181d01-as-fh-report-api",
           "/subscriptions/56c128b8-5ca9-4328-bb24-a11c829f4af9/resourceGroups/s181d01-familyhubs/providers/Microsoft.Web/sites/s181d01-as-fh-referral-ui",
           "/subscriptions/56c128b8-5ca9-4328-bb24-a11c829f4af9/resourceGroups/s181d01-familyhubs/providers/Microsoft.Web/sites/s181d01-as-fh-referral-api",
-          "/subscriptions/56c128b8-5ca9-4328-bb24-a11c829f4af9/resourceGroups/s181d01-familyhubs/providers/Microsoft.Web/sites/s181d01-as-fh-ref-dash-ui",
           "/subscriptions/56c128b8-5ca9-4328-bb24-a11c829f4af9/resourceGroups/s181d01-familyhubs/providers/Microsoft.Web/sites/s181d01-as-fh-notification-api",
           "/subscriptions/56c128b8-5ca9-4328-bb24-a11c829f4af9/resourceGroups/s181d01-familyhubs/providers/Microsoft.Web/sites/s181d01-as-fh-idam-api"
         ],

--- a/terraform/modules/fhinfrastructurestack/alerting.tf
+++ b/terraform/modules/fhinfrastructurestack/alerting.tf
@@ -20,8 +20,7 @@ data "azurerm_data_factory" "adf_dataf_default" {
 ####################################################################################################
 
 locals {
-  # All production alerts go into a separate silver monitor resource group otherwise add to the same resource group
-  alert_resource_group_name = var.environment == "Prod" ? "${var.prefix}-silverMonitor" : local.resource_group_name
+  alert_resource_group_name = local.resource_group_name
   
   gateway_details = {
     "referral-ui" = {


### PR DESCRIPTION
## Description

Dashboard UI has been merged with Connect, so remove the corresponding report item from the monitoring dashboard. 
Change the alerts resource group to the usual group (s181*-family-hubs) for preprod and prod. Attempted to reuse the s181*-silverHubs alerts-specific resource group which is managed by the central azure team, but some resource tags are defined by policy causing Terraform to apply needless updates to every alert. Example:

# module.fhinfrastructurestack.azurerm_monitor_metric_alert.app-gateway-backend-last-byte-response-time-alert["sd-ui"] will be updated in-place
  ~ resource "azurerm_monitor_metric_alert" "app-gateway-backend-last-byte-response-time-alert" {
        id                       = "/subscriptions/***/resourceGroups/s181p02-silverMonitor/providers/Microsoft.Insights/metricAlerts/s181p02-fh-appgw-sd-ui-backend-last-byte-response-time-alert"
        name                     = "s181p02-fh-appgw-sd-ui-backend-last-byte-response-time-alert"
      ~ tags                     = {
            "Environment"      = "Prod"
            "Parent Business"  = "Children's Care"
            "Portfolio"        = "Newly Onboarded"
          ~ "Product"          = "DfE Alert Monitoring" -> "Growing Up Well"
            "Service"          = "Children's Care"
            "Service Line"     = "Newly Onboarded"
          ~ "Service Offering" = "DfE Alert Monitoring" -> "Growing Up Well"
        }
        # (10 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

## Checklist

- [X] Jira ticket ID included in the title (unless not applicable)
- [X] Short, descriptive and sentence-case title used briefly describing the change
- [X] Commit messages are short, informative and accurate. When in doubt, use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation related to the change has been added/updated as appropriate
- [X] Changes have been given a once-over for spelling and grammar errors
- [ ] Tests have been added to cover any changes
